### PR TITLE
PARSERCLOUD-186 Fix formatting issues

### DIFF
--- a/content/parser/developer-guide/info-operations/_index.md
+++ b/content/parser/developer-guide/info-operations/_index.md
@@ -9,6 +9,3 @@ keywords: ""
 ---
 
 ### Info Operations ###
-
-
-

--- a/content/parser/developer-guide/info-operations/get-container-items-information.md
+++ b/content/parser/developer-guide/info-operations/get-container-items-information.md
@@ -13,11 +13,9 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
-This REST API endpoint allows retrieving container items (relative paths) from ZIP archives, documents that contain other attached documents like emails, PDF portfolios, MS Outlook storages.\\
-
-The table below contains the full list of properties. 
+This REST API endpoint allows retrieving container items (relative paths) from ZIP archives, documents that contain other attached documents like emails, PDF portfolios, MS Outlook storages. The table below contains the full list of properties.
 
 |Name|Description|Comment
 |---|---|---
@@ -27,40 +25,32 @@ The table below contains the full list of properties.
 |ContainerItemInfo.RelativePath|The relative path of the container.|Should be specified only for container files like ZIP archives, emails or PDF portfolios.
 |ContainerItemInfo.Password|Password for processing password-protected container items.|It should be specified only for password-protected container items.
 
-
-## Resources ##
-
-
+### Resources ###
 
 The following GroupDocs.Parser Cloud REST API resource has been used in the [get container items information](https://apireference.groupdocs.cloud/parser/#/Info/Container) example.
 
-```html 
-
+```html
 HTTP POST ~/container
+```
 
- ```
-
-
-## cURL Example ##
+### cURL Example ###
 
 The following example demonstrates how to get document information.
 
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
-
-
-
- Request
-
-```html 
-* First get JSON Web Token
-* Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications. Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
+```bash
+# First get JSON Web Token
+# Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications.
+# Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
 curl -v "https://api.groupdocs.cloud/connect/token" \
 -X POST \
 -d "grant_type#client_credentials&#x26;client_id#xxxx&#x26;client_secret#xxxx" \
 -H "Content-Type: application/x-www-form-urlencoded" \
 -H "Accept: application/json"
   
-* cURL example to join several documents into one
+# cURL example to join several documents into one
 curl -v "https://api.groupdocs.cloud/v1.0/parser/container" \
 -X POST \
 -H "Content-Type: application/json" \
@@ -73,14 +63,12 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/container" \
         "StorageName": ""
     }
 }"
- ```
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
- Response
-
-```html 
+```json
 {
     "containerItems": [
         {
@@ -103,48 +91,22 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/container" \
         }
     ]
 }
+```
 
- ```
+{{< /tab >}}
+{{< /tabs >}}
 
+### SDKs ###
 
+Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud) for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}}) article to learn how to add an SDK to your project.
 
+#### Get Container Items Information Examples ####
 
-
-
-## SDKs ##
-
-Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}})) article to learn how to add an SDK to your project.
-|---|---|---|---
-
-### Get Container Items Information Examples ###
-
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Get_Container_Information.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Get_Container_Information.java >}}
-
-
-
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/info-operations/get-document-information.md
+++ b/content/parser/developer-guide/info-operations/get-document-information.md
@@ -13,13 +13,9 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
-\\
-
-This REST API allows obtaining basic information about the document. The endpoint accepts the document storage path as input payload.
-
-Here is the list of properties that can be obtained for a document:
+This REST API allows obtaining basic information about the document. The endpoint accepts the document storage path as input payload. Here is the list of properties that can be obtained for a document:
 
 * Document file extension;
 * Document size in bytes;
@@ -27,8 +23,6 @@ Here is the list of properties that can be obtained for a document:
 * Document page count.
 
 The table below contains the full list of properties.
-
- 
 
 |Name|Description|Comment
 |---|---|---
@@ -38,52 +32,34 @@ The table below contains the full list of properties.
 |ContainerItemInfo.RelativePath|The relative path of the container.|Should be specified only for container files like ZIP archives, emails or PDF portfolios.
 |ContainerItemInfo.Password|Password for processing password-protected container items.|It should be specified only for password-protected container items.
 
-
-## Resources ##
+### Resources ###
 
 The following GroupDocs.Parser Cloud REST API resource has been used in the [Get Document Information](https://apireference.groupdocs.cloud/parser/#/Info/GetInfo) example.
-|---|---
 
 Resource URI
 
-
-
-
-
-
- 
-
-```html 
-
+```html
 HTTP POST ~/info
+```
 
- ```
-
- 
-
-
-
-
-## cURL Example ##
+### cURL Example ###
 
 The following example demonstrates how to get document information.
 
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
-
-
-
- Request
-
-```html 
-* First get JSON Web Token
-* Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications. Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
+```bash
+# First get JSON Web Token
+# Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications.
+# Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
 curl -v "https://api.groupdocs.cloud/connect/token" \
 -X POST \
 -d "grant_type#client_credentials&#x26;client_id#xxxx&#x26;client_secret#xxxx" \
 -H "Content-Type: application/x-www-form-urlencoded" \
 -H "Accept: application/json"
   
-* cURL example to get document information
+# cURL example to get document information
 curl -v "https://api.groupdocs.cloud/v1.0/parser/info" \
 -X POST \
 -H "Content-Type: application/json" \
@@ -91,14 +67,12 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/info" \
 -H "Authorization: Bearer 
 <jwt token>"
 -d "{ FilePath: '/words/four-pages.docx' }"
- ```
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
- Response
-
-```html 
+```json
 {
     "fileType": {
         "fileFormat": "Microsoft Word Open XML Document",
@@ -107,48 +81,22 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/info" \
     "size": 8651,
     "pageCount": 4
 }
+```
 
- ```
+{{< /tab >}}
+{{< /tabs >}}
 
+### SDKs ###
 
+Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud) for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}}) article to learn how to add an SDK to your project.
 
+#### Get Document Information Examples ####
 
-
-
-## SDKs ##
-
-Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}})) article to learn how to add an SDK to your project.
-|---|---|---|---
-
-### Get Document Information Examples ###
-
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Get_Document_Information.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Get_Document_Information.java >}}
-
-
-
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/info-operations/get-supported-file-types.md
+++ b/content/parser/developer-guide/info-operations/get-supported-file-types.md
@@ -13,72 +13,48 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
-This REST API allows getting a list of all [file formats supported ]({{< ref "parser/getting-started/supported-document-formats.md" >}}))by GroupDocs.Parser Cloud product.
-|---|---
+This REST API allows getting a list of all [file formats supported]({{< ref "parser/getting-started/supported-document-formats.md" >}}) by GroupDocs.Parser Cloud product.
 
-## Resources ##
+### Resources ###
 
 The following GroupDocs.Parser Cloud REST API resource has been used in the [get supported file types](https://apireference.groupdocs.cloud/parser/#/Info/GetSupportedFileFormats) example.
-|---|---
 
-
-
-
-
-
-
- 
-
-|
-|---
-
-
-
-
+```html
 HTTP POST ~~/formats
+```
 
-
-
-
- 
-
-
-
-
-## cURL Example ##
+### cURL Example ###
 
 The following example demonstrates how to get supported file types.
 
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
-
- Request
-
-```html 
-* First get JSON Web Token
-* Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications. Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
+```bash
+# First get JSON Web Token
+# Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications.
+# Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
 curl -v "https://api.groupdocs.cloud/connect/token" \
 -X POST \
 -d "grant_type#client_credentials&#x26;client_id#xxxx&#x26;client_secret#xxxx" \
 -H "Content-Type: application/x-www-form-urlencoded" \
 -H "Accept: application/json"
    
-* cURL example to get document information
+# cURL example to get document information
 curl -v "https://api.groupdocs.cloud/v1.0/parser/formats" \
 -X GET \
 -H "Content-Type: application/json" \
 -H "Accept: application/json" \
 -H "Authorization: Bearer 
 <jwt token>"
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
- ```
-
-
- Response
-
-```html 
+```json
 {
   "formats": [    
     {
@@ -93,47 +69,29 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/formats" \
       "extension": ".docx",
       "fileFormat": "Microsoft Word Open XML Document"
     },
-   ...
+    ...
     {
       "extension": ".xlsx",
       "fileFormat": "Microsoft Excel Open XML Spreadsheet"
     }
   ]
 }
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
- ```
+### SDKs ###
 
+Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud) for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}}) article to learn how to add an SDK to your project.
 
+#### Get Supported File Types Examples ####
 
-
-## SDKs ##
-
-Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}})) article to learn how to add an SDK to your project.
-|---|---|---|---
-
-### Get Supported File Types Examples ###
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Get_Document_File_Types.cs >}}
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Get_Document_File_Types.java >}}
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/parse-operations/_index.md
+++ b/content/parser/developer-guide/parse-operations/_index.md
@@ -9,6 +9,3 @@ keywords: ""
 ---
 
 ### Parse Operations ###
-
-
-

--- a/content/parser/developer-guide/parse-operations/extract-images/_index.md
+++ b/content/parser/developer-guide/parse-operations/extract-images/_index.md
@@ -13,7 +13,7 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
 This REST API provides the functionality to extract images from the document. There are following ways to extract images from a document:
 
@@ -23,10 +23,6 @@ This REST API provides the functionality to extract images from the document. Th
 It saves extracted images to the storage so they can be easily downloaded. The API allows extracting images from containers like ZIP archives, PDF portfolios, Email attachments, MS Outlook storages (PST/OST). For protected documents, it is also required to provide a password.
 
 The table below contains the full list of properties that can be specified when extracting images from a document.
-
-
-
- 
 
 |Name|Description|Comment
 |---|---|---
@@ -38,29 +34,12 @@ The table below contains the full list of properties that can be specified when 
 |StartPageNumber|Extraction start page.|The zero-based index.Extracts from the whole document if not specified.
 |CountPagesToExtract|The number of pages to extract.|Required if StartPageNumber is specified.
 
+### Resource URI ###
 
- 
-
-
-## Resource URI ##
-
-
-
- 
-
-```html 
-
+```html
 HTTP POST ~/images
-
- ```
-
- 
-
+```
 
 [Swagger UI](https://apireference.groupdocs.cloud/parser/#/Parse/Images) lets you call this REST API directly from the browser.  
-|---|---
 
-## Use Cases ##
-
-
-
+### Use Cases ###

--- a/content/parser/developer-guide/parse-operations/extract-images/extract-images-by-a-page-number-range.md
+++ b/content/parser/developer-guide/parse-operations/extract-images/extract-images-by-a-page-number-range.md
@@ -13,34 +13,32 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
 This REST API allows extracting images from specific pages only by setting pages range. This operation supports only documents with pages. You need to specify **StartPageNumber** and **CountPagesToExtract** parameters besides the basic options.
 
-## Resource ##
+### Resource ###
 
 The following GroupDocs.Parser Cloud REST API resource has been used in the [Extract images by a page number](https://apireference.groupdocs.cloud/parser/#/Parse/Images) example.
 
-## cURL Example ##
+### cURL Example ###
 
 The following example demonstrates how to extract images by a page number range.
 
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
-
-
-
- Request
-
-```html 
-* First get JSON Web Token
-* Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications. Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
+```bash
+# First get JSON Web Token
+# Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications.
+# Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
 curl -v "https://api.groupdocs.cloud/connect/token" \
 -X POST \
 -d "grant_type#client_credentials&#x26;client_id#xxxx&#x26;client_secret#xxxx" \
 -H "Content-Type: application/x-www-form-urlencoded" \
 -H "Accept: application/json"
    
-* cURL example to join several documents into one
+# cURL example to join several documents into one
 curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
 -X POST \
 -H "Content-Type: application/json" \
@@ -55,15 +53,12 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
         "StorageName": ""
     }
 }"
+```
 
- ```
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
-
- Response
-
-```html 
+```json
 {
     "pages": [
         {
@@ -86,49 +81,22 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
         }
     ]
 }
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
+### SDKs ###
 
- ```
+Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud) for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}}) article to learn how to add an SDK to your project.
 
+#### Extract Images by a Page Number Range Examples ####
 
-
-
-
-
-## SDKs ##
-
-Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}})) article to learn how to add an SDK to your project.
-
-### Extract Images by a Page Number Range Examples ###
-
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Extract_Images_Page_Number.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Extract_Images_Page_Number.java >}}
-
-
-
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/parse-operations/extract-images/extract-images-from-a-document-inside-a-container.md
+++ b/content/parser/developer-guide/parse-operations/extract-images/extract-images-from-a-document-inside-a-container.md
@@ -13,36 +13,32 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
 This REST API allows extracting images from a document placed in a container like ZIP archive, emails, PDF portfolios, etc. by specifying the **ContainerItemInfo** parameter.
 
-## Resource ##
+### Resource ###
 
 The following GroupDocs.Parser Cloud REST API resource has been used in the [Extract images from a document inside a container](https://apireference.groupdocs.cloud/parser/#/Parse/Images) example.
 
-## cURL Example ##
+### cURL Example ###
 
 The following example demonstrates how to extract images from a container item.
 
- 
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
-
-
-
-
- Request
-
-```html 
-* First get JSON Web Token
-* Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications. Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
+```bash
+# First get JSON Web Token
+# Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications.
+# Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
 curl -v "https://api.groupdocs.cloud/connect/token" \
 -X POST \
 -d "grant_type#client_credentials&#x26;client_id#xxxx&#x26;client_secret#xxxx" \
 -H "Content-Type: application/x-www-form-urlencoded" \
 -H "Accept: application/json"
    
-* cURL example to join several documents into one
+# cURL example to join several documents into one
 curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
 -X POST \
 -H "Content-Type: application/json" \
@@ -61,15 +57,12 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
         "RelativePath": "template-document.pdf"
     }
 }"
+```
 
- ```
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
-
- Response
-
-```html 
+```json
 {
     "pages": [
         {
@@ -92,48 +85,22 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
         }
     ]
 }
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
- ```
+### SDKs ###
 
+Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud) for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}}) article to learn how to add an SDK to your project.
 
+#### Extract Images from a Document Inside a Container Examples ####
 
-
-
-
-## SDKs ##
-
-Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}})) article to learn how to add an SDK to your project.
-
-### Extract Images from a Document Inside a Container Examples ###
-
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Extract_Images_Document_Container.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Extract_Images_Document_Container.java >}}
-
-
-
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/parse-operations/extract-images/extract-images-from-the-whole-document.md
+++ b/content/parser/developer-guide/parse-operations/extract-images/extract-images-from-the-whole-document.md
@@ -13,34 +13,32 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
 This REST API allows extracting images from the whole document by default. Document could be a file of any supported formats.You need to specify only the file information parameters.
 
-## Resource ##
+## Resource ###
 
 The following GroupDocs.Parser Cloud REST API resource has been used in the [extract image from the whole document](https://apireference.groupdocs.cloud/parser/#/Parse/Images) example.
 
-## cURL Example ##
+### cURL Example ###
 
 The following example demonstrates how to extract text from the whole document.
 
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
-
-
-
- Request
-
-```html 
-* First get JSON Web Token
-* Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications. Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
+```bash
+# First get JSON Web Token
+# Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications.
+# Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
 curl -v "https://api.groupdocs.cloud/connect/token" \
 -X POST \
 -d "grant_type#client_credentials&#x26;client_id#xxxx&#x26;client_secret#xxxx" \
 -H "Content-Type: application/x-www-form-urlencoded" \
 -H "Accept: application/json"
    
-* cURL example to join several documents into one
+# cURL example to join several documents into one
 curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
 -X POST \
 -H "Content-Type: application/json" \
@@ -53,16 +51,12 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
         "StorageName": ""
     }
 }"
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
- ```
-
-
-
-
- Response
-
-```html 
+```json
 {
     "images": [
         {
@@ -83,48 +77,22 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
         }
     ]
 }
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
- ```
+### SDKs ###
 
+Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud) for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}}) article to learn how to add an SDK to your project.
 
+#### Extract Images From The Whole Document Examples ####
 
-
-
-
-## SDKs ##
-
-Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}})) article to learn how to add an SDK to your project.
-
-### Extract Images From The Whole Document Examples ###
-
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Extract_Images_Whole_Document.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Extract_Images_Whole_Document.java >}}
-
-
-
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/parse-operations/extract-text/_index.md
+++ b/content/parser/developer-guide/parse-operations/extract-text/_index.md
@@ -13,7 +13,7 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
 This REST API provides the functionality to extract text from the document.
 There are several ways to extract text from a document:
@@ -24,9 +24,6 @@ There are several ways to extract text from a document:
 
 For protected documents, it is also required to provide a password.
 The table below contains the full list of properties that can be specified when extracting text from a document.
-
-
- 
 
 |Name|Description|Comment
 |---|---|---
@@ -39,28 +36,12 @@ The table below contains the full list of properties that can be specified when 
 |StartPageNumber|Extraction start page.|The zero-based index. Extracts all pages if not specified.
 |CountPagesToExtract|The number of pages to extract.|Required if StartPageNumber is specified.
 
+### Resource URI ###
 
-## Resource URI ##
-
-
-
- 
-
-```html 
-
+```html
 HTTP POST ~/text
-
- ```
-
- 
-
+```
 
 [Swagger UI](https://apireference.groupdocs.cloud/parser/#/Parse/Text) lets you call this REST API directly from the browser.  
-|---|---
 
-## Use Cases ##
-
-
-
-
-
+### Use Cases ###

--- a/content/parser/developer-guide/parse-operations/extract-text/extract-formatted-text.md
+++ b/content/parser/developer-guide/parse-operations/extract-text/extract-formatted-text.md
@@ -13,34 +13,32 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
-This REST API allows extracting formatted text by setting the pages extraction mode option. You need to specify the** FormattedTextOptions** Mode parameter besides the basic options.
+This REST API allows extracting formatted text by setting the pages extraction mode option. You need to specify the **FormattedTextOptions** Mode parameter besides the basic options.
 
-## Resource ##
+### Resource ###
 
 The following GroupDocs.Parser Cloud REST API resource has been used in the [Extract formatted text](https://apireference.groupdocs.cloud/parser/#/Parse/Text) example.
 
-## cURL Example ##
+### cURL Example ###
 
 The following example demonstrates how to extract formatted text.
 
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
-
-
-
- Request
-
-```html 
-* First get JSON Web Token
-* Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications. Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
+```bash
+# First get JSON Web Token
+# Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications.
+# Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
 curl -v "https://api.groupdocs.cloud/connect/token" \
 -X POST \
 -d "grant_type#client_credentials&#x26;client_id#xxxx&#x26;client_secret#xxxx" \
 -H "Content-Type: application/x-www-form-urlencoded" \
 -H "Accept: application/json"
    
-* cURL example to join several documents into one
+# cURL example to join several documents into one
 curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
 -X POST \
 -H "Content-Type: application/json" \
@@ -56,16 +54,12 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
         "StorageName": ""
     }
 }"
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
- ```
-
-
-
-
- Response
-
-```html 
+```json
 {
     "text": "
 <p>
@@ -135,48 +129,22 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
 <h1>Second page heading
 </h1>"
 }
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
- ```
+### SDKs ###
 
+Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud) for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}}) article to learn how to add an SDK to your project.
 
+#### Extract Text From The Whole Document Examples ####
 
-
-
-
-## SDKs ##
-
-Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}})) article to learn how to add an SDK to your project.
-
-### Extract Text From The Whole Document Examples ###
-
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Extract_Formetted_Text.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Extract_Formetted_Text.java >}}
-
-
-
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/parse-operations/extract-text/extract-text-by-a-page-number-range.md
+++ b/content/parser/developer-guide/parse-operations/extract-text/extract-text-by-a-page-number-range.md
@@ -13,34 +13,32 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
 This REST API allows extracting text from specific pages only by setting pages range. You need to specify **StartPageNumber** and **CountPagesToExtract** parameters besides the basic options.
 
-## Resource ##
+### Resource ###
 
 The following GroupDocs.Parser Cloud REST API resource has been used in the [Extract text by a page number](https://apireference.groupdocs.cloud/parser/#/Parse/Text) example.
 
-## cURL Example ##
+### cURL Example ###
 
 The following example demonstrates how to extract text by a page number range.
 
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
-
-
-
- Request
-
-```html 
-* First get JSON Web Token
-* Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications. Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
+```bash
+# First get JSON Web Token
+# Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications.
+# Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
 curl -v "https://api.groupdocs.cloud/connect/token" \
 -X POST \
 -d "grant_type#client_credentials&#x26;client_id#xxxx&#x26;client_secret#xxxx" \
 -H "Content-Type: application/x-www-form-urlencoded" \
 -H "Accept: application/json"
    
-* cURL example to join several documents into one
+# cURL example to join several documents into one
 curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
 -X POST \
 -H "Content-Type: application/json" \
@@ -55,16 +53,12 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
         "StorageName": ""
     }
 }"
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
- ```
-
-
-
-
- Response
-
-```html 
+```json
 {
     "pages": [
         {
@@ -85,48 +79,22 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
         }
     ]
 }
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
- ```
+### SDKs ###
 
+Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud) for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}}) article to learn how to add an SDK to your project.
 
+#### Extract Text by a Page Number Range Examples ####
 
-
-
-
-## SDKs ##
-
-Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}})) article to learn how to add an SDK to your project.
-
-### Extract Text by a Page Number Range Examples ###
-
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Extract_Text_Page_Number.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Extract_Text_Page_Number.java >}}
-
-
-
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/parse-operations/extract-text/extract-text-from-a-document-inside-a-container.md
+++ b/content/parser/developer-guide/parse-operations/extract-text/extract-text-from-a-document-inside-a-container.md
@@ -13,36 +13,32 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
 This REST API allows extracting text from a document placed in a container like ZIP archive, emails, PDF portfolios, etc. by specifying **ContainerItemInfo** parameter
 
-## Resource ##
+### Resource ###
 
 The following GroupDocs.Parser Cloud REST API resource has been used in the [Extract Text From a Document Inside a Container](https://apireference.groupdocs.cloud/parser/#/Parse/Text) example.
 
-## cURL Example ##
+### cURL Example ###
 
 The following example demonstrates how to extract text from a container item.
 
- 
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
-
-
-
-
- Request
-
-```html 
-* First get JSON Web Token
-* Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications. Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
+```bash
+# First get JSON Web Token
+# Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications.
+# Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
 curl -v "https://api.groupdocs.cloud/connect/token" \
 -X POST \
 -d "grant_type#client_credentials&#x26;client_id#xxxx&#x26;client_secret#xxxx" \
 -H "Content-Type: application/x-www-form-urlencoded" \
 -H "Accept: application/json"
    
-* cURL example to join several documents into one
+# cURL example to join several documents into one
 curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
 -X POST \
 -H "Content-Type: application/json" \
@@ -60,61 +56,31 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
         "Password": "password"
     }
 }"
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
- ```
-
-
-
-
- Response
-
-```html 
+```json
 {
     "text": "Text inside bookmark 0\r\n\r\n           Page 0 heading\r\nP a g e  T e x t -  P a g e  0\r\nText inside bookmark 1\r\n\r\n           Page 1 heading\r\nP a g e  T e x t -  P a g e  1\r\nText inside bookmark 2\r\n\r\n           Page 2 heading\r\nP a g e  T e x t -  P a g e  2\r\nText inside bookmark 3\r\n\r\n           Page 3 heading\r\nP a g e  T e x t -  P a g e  3\r\nField\r\nRelatedField2 RelatedText2\r\n REGEX TEXT 123\r\nTABLE\r\n    Cell\r\n                         Cell 12\r\n\r\n\r\n\r\n"
 }
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
- ```
+### SDKs ###
 
+Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud) for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}}) article to learn how to add an SDK to your project.
 
+#### Extract Text From a Document Inside a Container Example ####
 
-
-
-
-## SDKs ##
-
-Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}})) article to learn how to add an SDK to your project.
-
-### Extract Text From a Document Inside a Container Example ###
-
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Extract_Text_Document_Container.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Extract_Text_Document_Container.java >}}
-
-
-
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/parse-operations/extract-text/extract-text-from-the-whole-document.md
+++ b/content/parser/developer-guide/parse-operations/extract-text/extract-text-from-the-whole-document.md
@@ -13,34 +13,32 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
 This REST API allows extracting text from the whole document by default. You need to specify only the file information parameters.
 
-## Resource ##
+### Resource ###
 
 The following GroupDocs.Parser Cloud REST API resource has been used in the [extract text from the whole document](https://apireference.groupdocs.cloud/parser/#/Parse/Text) example.
 
-## cURL Example ##
+### cURL Example ###
 
 The following example demonstrates how to extract text from the whole document.
 
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
-
-
-
- Request
-
-```html 
-* First get JSON Web Token
-* Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications. Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
+```bash
+# First get JSON Web Token
+# Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications.
+# Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
 curl -v "https://api.groupdocs.cloud/connect/token" \
 -X POST \
 -d "grant_type#client_credentials&#x26;client_id#xxxx&#x26;client_secret#xxxx" \
 -H "Content-Type: application/x-www-form-urlencoded" \
 -H "Accept: application/json"
   
-* cURL example to join several documents into one
+$ cURL example to join several documents into one
 curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
 -X POST \
 -H "Content-Type: application/json" \
@@ -52,57 +50,31 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/text" \
             "FilePath": "words\docx\document.docx",
     }
 }"
- ```
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
- Response
-
-```html 
+```json
 {
     "text": "First Page\r\r\f"
 }
- ```
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
+### SDKs ###
 
+Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud) for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}}) article to learn how to add an SDK to your project.
 
+#### Extract Text From The Whole Document Examples ####
 
-
-## SDKs ##
-
-Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}})) article to learn how to add an SDK to your project.
-
-### Extract Text From The Whole Document Examples ###
-
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Extract_Text_Whole_Document.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Extract_Text_Whole_Document.java >}}
-
-
-
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/parse-operations/parse-by-template/_index.md
+++ b/content/parser/developer-guide/parse-operations/parse-by-template/_index.md
@@ -13,17 +13,13 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
 This REST API provides the functionality to extract data from documents. This method parses document content by a user-generated template.
 
 The template can be provided as an object or storage path. For protected documents, it is also required to provide a password.
 
 The table below contains the full list of properties that can be specified when parsing documents by a template.
-
-
-
- 
 
 |Name|Description|Comment
 |---|---|---
@@ -35,10 +31,7 @@ The table below contains the full list of properties that can be specified when 
 |TemplatePath|The path of the file, located in the storage, which contains a user-generated template to parse data. It is used when the template parameter is not provided. |The template must be provided by this field or by Template.
 |Template|User-generated [template]("TemplateTemplateParametersTable") object to extract metadata from the document. |Template must be provided by this field or by TemplatePath.
 
-
-## Template ##
-
-{{id name#"TemplateParametersTable"/}}
+### Template ###
 
 |Name|Description|Comment
 |---|---|---
@@ -55,63 +48,45 @@ The table below contains the full list of properties that can be specified when 
 |FieldPosition.IsTopLinked|The value that indicates whether a field is searched by the top from the linked field.|Is used if “Linked” FieldPositionType is set.
 |FieldPosition.IsBottomLinked|The value that indicates whether a field is searched by the bottom from the linked field.|Is used if “Linked” FieldPositionType is set.
 |FieldPosition.SearchArea|The size of the area where a field is searched.|Required if “Linked” FieldPositionType is set.
-|SearchArea.Height|The height of search area.| 
-|SearchArea.Width|The width of search area.| 
+|SearchArea.Height|The height of search area.|
+|SearchArea.Width|The width of search area.|
 |FieldPosition.AutoScale|The value that indicates whether SearchArea is scaled by the linked field size.|Is used if “Linked” FieldPositionType is set.
 |Template.Tables|Template tables.|Required if Template.Fields are not provided.
 |Table.FieldName|A unique template table name.|Required.
 |Table.PageIndex|The page index.|An integer value that represents the index of the page where the template item is located; null if the template item is located on any page.
 |Table.DetectorParametes|Provides parameters for the table detection algorithms.|Required if TableLayout is not provided.
-|DetectorParameters.MinRowCount|The minimum number of the table rows.| 
-|DetectorParameters.MinColumnCount|The minimum number of the table columns.| 
-|DetectorParameters.MinVerticalSpace|The minimum space between the table columns.| 
-|DetectorParameters.HasMergedCells|The value that indicates whether the table has merged cells.| 
-|DetectorParameters.Rectangle|The [rectangular area]("RectangleRectangleParametersTable") that contains the table.| 
-|DetectorParameters.VerticalSeparators|The table columns separators.| 
+|DetectorParameters.MinRowCount|The minimum number of the table rows.|
+|DetectorParameters.MinColumnCount|The minimum number of the table columns.|
+|DetectorParameters.MinVerticalSpace|The minimum space between the table columns.|
+|DetectorParameters.HasMergedCells|The value that indicates whether the table has merged cells.|
+|DetectorParameters.Rectangle|The [rectangular area]("RectangleRectangleParametersTable") that contains the table.|
+|DetectorParameters.VerticalSeparators|The table columns separators.|
 |Table.TableLayout|Provides the template table layout which is used Table to define table position.|Required if DetectorParameters is not provided.
-|TableLayout.VerticalSeparators|The table columns separators.| 
-|TableLayout.HorizontalSeparators|The table rows separators.| 
+|TableLayout.VerticalSeparators|The table columns separators.|
+|TableLayout.HorizontalSeparators|The table rows separators.|
 
-
-## Rectangle ##
-
-{{id name#"RectangleParametersTable"/}}
+### Rectangle ###
 
 |Name|Description|Comment
 |---|---|---
 |Rectangle.Position|The coordinates of the upper-left corner of the rectangular area.|Required if Rectangle.Coordinates is not provided.
-|Position.X|X-coordinate of upper-left rectangle corner.| 
-|Position.Y|Y-coordinate of upper-left rectangle corner.| 
+|Position.X|X-coordinate of upper-left rectangle corner.|
+|Position.Y|Y-coordinate of upper-left rectangle corner.|
 |Rectangle.Size|Represents a size of rectangular area.|Required if Rectangle.Coordinates is not provided.
-|Size.Height|The height of rectangular area.| 
-|Size.Width|The width of rectangular area.| 
-|Rectangle.Coordinates|Coordinates of the rectangular area edges.| 
-|Coordinates.Top|The y-coordinate of the top edge of the rectangular area.| 
-|Coordinates.Right|The x-coordinate of the right edge of the rectangular area.| 
-|Coordinates.Left|The x-coordinate of the left edge of the rectangular area.| 
-|Coordinates.Bottom|The y-coordinate of the bottom edge of the rectangular area.| 
+|Size.Height|The height of rectangular area.|
+|Size.Width|The width of rectangular area.|
+|Rectangle.Coordinates|Coordinates of the rectangular area edges.|
+|Coordinates.Top|The y-coordinate of the top edge of the rectangular area.|
+|Coordinates.Right|The x-coordinate of the right edge of the rectangular area.|
+|Coordinates.Left|The x-coordinate of the left edge of the rectangular area.|
+|Coordinates.Bottom|The y-coordinate of the bottom edge of the rectangular area.|
 
+### Resource URI ###
 
- 
-
-
-## Resource URI ##
-
-
-
- 
-
-```html 
-
+```html
 HTTP POST ~/parse
-
- ```
-
- 
-
+```
 
 [Swagger UI](https://apireference.groupdocs.cloud/parser/#/Parse/Parse) lets you call this REST API directly from the browser.  
-|---|---
 
-## Use Cases ##
-
+### Use Cases ###

--- a/content/parser/developer-guide/parse-operations/parse-by-template/parse-by-template-defined-as-an-object.md
+++ b/content/parser/developer-guide/parse-operations/parse-by-template/parse-by-template-defined-as-an-object.md
@@ -13,34 +13,32 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
 This REST API allows us to extract document's fields and tables defined in a template object passed as a method parameter.
 
 The following example demonstrates how to extract data from a source document by a user-defined template. Here you can see how to parse text fields by regular expressions and a table inside the document.
 
-## Resource ##
+### Resource ###
 
 The following GroupDocs.Parser Cloud REST API resource has been used in the [Parse by Template defined as an object](https://apireference.groupdocs.cloud/parser/#/Template) example.
 
-## cURL Example ##
+### cURL Example ###
 
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
-
-
-
- Request
-
-```html 
-* First get JSON Web Token
-* Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications. Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
+```bash
+# First get JSON Web Token
+# Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications.
+# Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
 curl -v "https://api.groupdocs.cloud/connect/token" \
 -X POST \
 -d "grant_type#client_credentials&#x26;client_id#xxxx&#x26;client_secret#xxxx" \
 -H "Content-Type: application/x-www-form-urlencoded" \
 -H "Accept: application/json"
   
-* cURL example to join several documents into one
+# cURL example to join several documents into one
 curl -v "https://api.groupdocs.cloud/v1.0/parser/parse" \
 -X POST \
 -H "Content-Type: application/json" \
@@ -114,14 +112,12 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/parse" \
         "StorageName": ""
     }
 }"
- ```
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
- Response
-
-```html 
+```json
 {
     "count": 5,
     "fieldsData": [
@@ -502,46 +498,22 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/parse" \
         }
     ]
 }
- ```
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-## SDKs ##
+### SDKs ###
 
 Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [Parser API](https://apireference.groupdocs.cloud/parser/#/Parse) calls and lets you use GroupDocs Cloud features in a native way for your preferred language.
 
-### Parse by Template Defined as an Object Examples ###
+#### Parse by Template Defined as an Object Examples ####
 
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Parse_by_Template_defined_objectcs.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Parse_by_Template_defined_objectcs.java >}}
-
-
-
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/parse-operations/parse-by-template/parse-by-template-of-a-document-inside-a-container.md
+++ b/content/parser/developer-guide/parse-operations/parse-by-template/parse-by-template-of-a-document-inside-a-container.md
@@ -13,34 +13,32 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
 This REST API allows extracting fields and tables from a document placed in a container like ZIP archive, emails, PDF portfolios, etc. by specifying the ContainerItemInfo parameter.
 
 The following example demonstrates how to extract data from a container item. Here you can see how to parse text fields by regular expressions and a table inside the container item document.
 
-## Resource ##
+### Resource ###
 
 The following GroupDocs.Parser Cloud REST API resource has been used in the [Parse by Template of a document inside a container](https://apireference.groupdocs.cloud/parser/#/Template) example.
 
-## cURL Example ##
+### cURL Example ###
 
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
-
-
-
- Request
-
-```html 
-* First get JSON Web Token
-* Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications. Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
+```bash
+# First get JSON Web Token
+# Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications.
+# Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
 curl -v "https://api.groupdocs.cloud/connect/token" \
 -X POST \
 -d "grant_type#client_credentials&#x26;client_id#xxxx&#x26;client_secret#xxxx" \
 -H "Content-Type: application/x-www-form-urlencoded" \
 -H "Accept: application/json"
   
-* cURL example to join several documents into one
+# cURL example to join several documents into one
 curl -v "https://api.groupdocs.cloud/v1.0/parser/parse" \
 -X POST \
 -H "Content-Type: application/json" \
@@ -56,14 +54,12 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/parse" \
         "RelativePath": "companies.docx"
     }
 }"
- ```
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
- Response
-
-```html 
+```json
 {
     "count": 5,
     "fieldsData": [
@@ -444,46 +440,22 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/parse" \
         }
     ]
 }
- ```
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-## SDKs ##
+### SDKs ###
 
 Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [Parser API](https://apireference.groupdocs.cloud/parser/#/Parse) calls and lets you use GroupDocs Cloud features in a native way for your preferred language.
 
-### Parse by Template of a Document Inside a Container Examples ###
+#### Parse by Template of a Document Inside a Container Examples ####
 
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Parse_by_Template_document_inside_container.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Parse_by_Template_document_inside_container.java >}}
-
-
-
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/parse-operations/parse-by-template/parse-by-template-stored-in-user-storage.md
+++ b/content/parser/developer-guide/parse-operations/parse-by-template/parse-by-template-stored-in-user-storage.md
@@ -13,34 +13,32 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
 This REST API allows extracting document's fields and tables defined in a template file saved in user storage and specified by template path.
 
 The following example demonstrates how to extract data from a source document by a saved template. Here you can see how to parse text fields by regular expressions and a table inside the document.
 
-## Resource ##
+### Resource ###
 
 The following GroupDocs.Parser Cloud REST API resource has been used in the [Parse by Template Store in User Storage](https://apireference.groupdocs.cloud/parser/#/Template) example.
 
-## cURL Example ##
+### cURL Example ###
 
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
-
-
-
- Request
-
-```html 
-* First get JSON Web Token
-* Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications. Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
+```bash
+# First get JSON Web Token
+# Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications.
+# Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
 curl -v "https://api.groupdocs.cloud/connect/token" \
 -X POST \
 -d "grant_type#client_credentials&#x26;client_id#xxxx&#x26;client_secret#xxxx" \
 -H "Content-Type: application/x-www-form-urlencoded" \
 -H "Accept: application/json"
   
-* cURL example to join several documents into one
+# cURL example to join several documents into one
 curl -v "https://api.groupdocs.cloud/v1.0/parser/parse" \
 -X POST \
 -H "Content-Type: application/json" \
@@ -53,14 +51,12 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/parse" \
         "TemplatePath": "templates\template-for-companies.json"
     }
 }"
- ```
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
- Response
-
-```html 
+```json
 {
     "count": 5,
     "fieldsData": [
@@ -441,46 +437,22 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/parse" \
         }
     ]
 }
- ```
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-## SDKs ##
+### SDKs ###
 
 Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [Parser API](https://apireference.groupdocs.cloud/parser/#/Parse) calls and lets you use GroupDocs Cloud features in a native way for your preferred language.
 
-### Parse by Template Stored in User Storage Examples ###
+#### Parse by Template Stored in User Storage Examples ####
 
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Template_Stored_User_Storage.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Template_Stored_User_Storage.java >}}
-
-
-
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/storage-operations/working-with-files.md
+++ b/content/parser/developer-guide/storage-operations/working-with-files.md
@@ -13,138 +13,93 @@ keywords: ""
 
 
 
-# Download File API #
+## Download File API ##
 
 This API allows you to download a file from [GroupDocs Cloud Storage](https://dashboard.groupdocs.cloud).
-|---|---
 
-## API Explorer ##
+### API Explorer ###
 
 [GroupDocs.Parser Cloud API Reference](https://apireference.groupdocs.cloud/parser/#/) lets you try out [Download a File API](https://apireference.groupdocs.cloud/parser/#/File/DownloadFile) right away in your browser! It allows you to effortlessly interact and try out every single operation our APIs expose.
-|---|---|---|---
 
-### Request parameters ###
+#### Request parameters ####
 
 |Parameter|Description
 |---|---
-|**Path**|Path of the file including file name and extension e.g. /Folder1/file.ext
-
- Required. Can be passed as a query string parameter or as part of the URL
+|**Path**|Path of the file including file name and extension e.g. /Folder1/file.ext</br>Required. Can be passed as a query string parameter or as part of the URL
 |storageName|Name of the storage. If not set, then default storage used
 |versionId|File version id
 
+### cURL Example ###
 
-## cURL Example ##
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
+```bash
+curl -X GET "https://api.groupdocs.cloud/v1.0/parser/storage/file/one-page.docx?storageName#MyStorage" \
+-H  "accept: multipart/form-data" \
+-H  "authorization: Bearer [Access Token]"
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
- Request
-
-```html 
-curl -X GET "https://api.groupdocs.cloud/v1.0/parser/storage/file/one-page.docx?storageName#MyStorage" -H  "accept: multipart/form-data" -H  "authorization: Bearer [Access Token]"
-    
- ```
-
-
-
-
- Response
-
-```html 
+```json
 {
   "Code": 200,
   "Status": "OK"
 }
- ```
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-## SDKs ##
+### SDKs ###
 
 Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [File API](https://apireference.groupdocs.cloud/parser/#/) calls and lets you use GroupDocs Cloud features in a native way for your preferred language.
-|---|---|---|---|---|---
 
-### SDK Examples ###
+#### SDK Examples ####
 
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Download_File.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Download_File.java >}}
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-
-
-
-
-#  Upload File API #
+## Upload File API ##
 
 This API allows you to upload files to the [GroupDocs Cloud Storage](https://dashboard.groupdocs.cloud/).
-|---|---
 
-## API Explorer ##
+### API Explorer ###
 
 [GroupDocs.Parser Cloud API Reference](https://apireference.groupdocs.cloud/parser/#/) lets you try out [Upload a File API](https://apireference.groupdocs.cloud/parser/#/File/UploadFile) right away in your browser! It allows you to effortlessly interact and try out every single operation our APIs expose.
-|---|---|---|---
 
-
-### Request Body parameters ###
+#### Request Body parameters ####
 
 |Parameter|Description
 |---|---
-|**path**|Path of the file including file name and extension e.g. /Folder1/file.ext
-
- Required. Can be passed as a query string parameter or as part of the URL
+|**path**|Path of the file including file name and extension e.g. /Folder1/file.ext</br>Required. Can be passed as a query string parameter or as part of the URL
 |storageName|Name of the storage. If not set, then default storage used
 |File|File content
 
+### cURL Example ###
 
-## cURL Example ##
+{{< tabs tabTotal="2" tabID="3" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
+```bash
+curl -X POST "https://api.groupdocs.cloud/v1.0/parser/storage/file/parserdocs%2Fone-page2.docx?storageName#MyStorage" \
+-H  "accept: application/json" \
+-H  "authorization: Bearer [Access Token]"
+```
 
-
-
-
- Request
-
-```html 
-curl -X POST "https://api.groupdocs.cloud/v1.0/parser/storage/file/parserdocs%2Fone-page2.docx?storageName#MyStorage" -H  "accept: application/json" -H  "authorization: Bearer [Access Token]"
-
- ```
-
-
-
-
- Response
-
-```html 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 Http status code: 200 (Returns OK and list of errors, which is empty if success.)
+
+```json
 {
   "Uploaded": [
     "string"
@@ -161,324 +116,191 @@ Http status code: 200 (Returns OK and list of errors, which is empty if success.
     }
   ]
 }
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
- ```
-
-
-
-
-
-
-## SDKs ##
+### SDKs ###
 
 Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [File API](https://apireference.groupdocs.cloud/parser/#/File) calls and lets you use GroupDocs for Cloud features in a native way for your preferred language.
-|---|---|---|---|---|---
 
-### SDK Examples ###
+#### SDK Examples ####
 
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="4" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Upload_File.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Upload_File.java >}}
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-
-
-
-
-# Delete File API #
+## Delete File API ##
 
 This API allows you to delete a specific file from [GroupDocs Cloud Storage](https://dashboard.groupdocs.cloud/).
-|---|---
 
-## API Explorer ##
+### API Explorer ###
 
 [GroupDocs.Parser for Cloud API Reference](https://apireference.groupdocs.cloud/parser/#/) lets you try out [Delete a File](https://apireference.groupdocs.cloud/parser/#/File/DeleteFile) right away in your browser! It allows you to effortlessly interact and try out every single operation our APIs exposes.
-|---|---|---|---
 
-
-### Request parameters ###
+#### Request parameters ####
 
 |Parameter|Description
 |---|---
-|**path**|Path of the file including file name and extension e.g. /Folder1/file.ext
-
- Required. Can be passed as a query string parameter or as part of the URL
+|**path**|Path of the file including file name and extension e.g. /Folder1/file.ext</br>Required. Can be passed as a query string parameter or as part of the URL
 |storageName|Name of the storage. If not set, then default storage used
 |versionId|File version id
 
+### cURL Example ###
 
-## cURL Example ##
+{{< tabs tabTotal="2" tabID="5" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
+```bash
+curl -X DELETE "https://api.groupdocs.cloud/v1.0/parser/storage/file/parserdocs1%2Fone-page1.docx?storageName#MyStorage" \
+-H  "accept: application/json" \
+-H  "authorization: Bearer [Access Token]"
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
- Request
-
-```html 
-curl -X DELETE "https://api.groupdocs.cloud/v1.0/parser/storage/file/parserdocs1%2Fone-page1.docx?storageName#MyStorage" -H  "accept: application/json" -H  "authorization: Bearer [Access Token]"
-
- ```
-
-
-
-
- Response
-
-```html 
+```json
 {
   "Code": 200,
   "Status": "OK"
 }
- ```
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-## SDKs ##
+### SDKs ###
 
 Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [File API](https://apireference.groupdocs.cloud/parser/#/File) calls and lets you use GroupDocs for Cloud features in a native way for your preferred language.
-|---|---|---|---|---|---
 
-### SDK Examples ###
+#### SDK Examples ####
 
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="6" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Delete_File.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Delete_File.java >}}
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-
-
-
-
-# File Copy API #
+## File Copy API ##
 
 This API allows you to copy a specific file from [GroupDocs Cloud Storage](https://dashboard.groupdocs.cloud/).
-|---|---
 
-## API Explorer ##
+### API Explorer ###
 
-[GroupDocs.Parser for Cloud API Reference](https://apireference.groupdocs.cloud/parser/#/) lets you try out [Copy File](https://apireference.groupdocs.cloud/parser/#/File/CopyFile) right away in your browser! It allows you to effortlessly interact and try out every single operation our APIs expose. 
-|---|---|---|---
+[GroupDocs.Parser for Cloud API Reference](https://apireference.groupdocs.cloud/parser/#/) lets you try out [Copy File](https://apireference.groupdocs.cloud/parser/#/File/CopyFile) right away in your browser! It allows you to effortlessly interact and try out every single operation our APIs expose.
 
-###  Request parameters ###
+####  Request parameters ####
 
 |Parameter|Description
 |---|---
-|**srcPath**|Path of the source file including file name and extension e.g. /Folder1/file.ext
-
-Required. Can be passed as a query string parameter or as part of the URL
+|**srcPath**|Path of the source file including file name and extension e.g. /Folder1/file.ext</br>Required. Can be passed as a query string parameter or as part of the URL
 |**destPath**|Path of the destination file. Required.
 |srcStorageName|Name of the storage of source file. If not set, then default storage used
 |destStorageName|Name of the storage of destination file. If not set, then default storage used
 |versionId|Source file version id
 
+### cURL Example ###
 
-## cURL Example ##
+{{< tabs tabTotal="2" tabID="7" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
+```bash
+curl -X PUT "https://api.groupdocs.cloud/v1.0/parser/storage/file/copy/parserdocs%2Fone-page1.docx?destPath#parserdocs1%2Fone-page1.docx'&#x26;srcStorageName#MyStorage&#x26;destStorageName#MyStorage" \
+-H  "accept: application/json" \
+-H  "authorization: Bearer [Access Token]"
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
- Request
-
-```html 
-curl -X PUT "https://api.groupdocs.cloud/v1.0/parser/storage/file/copy/parserdocs%2Fone-page1.docx?destPath#parserdocs1%2Fone-page1.docx'&#x26;srcStorageName#MyStorage&#x26;destStorageName#MyStorage" -H  "accept: application/json" -H  "authorization: Bearer [Access Token]"
-    
- ```
-
-
-
-
- Response
-
-```html 
+```json
 {
   "Code": 200,
   "Status": "OK"
 }
- ```
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-## SDKs ##
+### SDKs ###
 
 Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [File API](https://apireference.groupdocs.cloud/parser/#/File) calls and lets you use GroupDocs Cloud features in a native way for your preferred language.
-|---|---|---|---|---|---
 
-### SDK Examples ###
+#### SDK Examples ####
 
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="8" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Copy_File.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Copy_File.java >}}
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-
-
-
-
-# File Move API #
+## File Move API ##
 
 This API allows you to copy a specific file from [GroupDocs Cloud Storage](https://dashboard.groupdocs.cloud/).
-|---|---
 
-## API Explorer ##
+### API Explorer ###
 
-[GroupDocs.Parser for Cloud API Reference](https://apireference.groupdocs.cloud/parser/#/) lets you try out [Move File](https://apireference.groupdocs.cloud/parser/#/File/MoveFile) right away in your browser! It allows you to effortlessly interact and try out every single operation our APIs expose. 
-|---|---|---|---
+[GroupDocs.Parser for Cloud API Reference](https://apireference.groupdocs.cloud/parser/#/) lets you try out [Move File](https://apireference.groupdocs.cloud/parser/#/File/MoveFile) right away in your browser! It allows you to effortlessly interact and try out every single operation our APIs expose.
 
-###  Request parameters ###
+####  Request parameters ####
 
 |Parameter|Description
 |---|---
-|**srcPath**|Path of the source file including file name and extension e.g. /Folder1/file.ext
-
-Required. Can be passed as a query string parameter or as part of the URL
+|**srcPath**|Path of the source file including file name and extension e.g. /Folder1/file.ext</br>Required. Can be passed as a query string parameter or as part of the URL
 |**destPath**|Path of the destination file. Required.
 |srcStorageName|Name of the storage of source file. If not set, then default storage used
 |destStorageName|Name of the storage of destination file. If not set, then default storage used
 |versionId|Source file version id
 
+### cURL Example ###
 
-## cURL Example ##
+{{< tabs tabTotal="2" tabID="9" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
+```bash
+curl -X PUT "https://api.groupdocs.cloud/v1.0/parser/storage/file/move/parserdocs%2Fone-page1.docx?destPath#parserdocs1%2Fone-page1.docx'&#x26;srcStorageName#MyStorage&#x26;destStorageName#MyStorage" \
+-H  "accept: application/json" \
+-H  "authorization: Bearer [Access Token]"
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
- Request
-
-```html 
-curl -X PUT "https://api.groupdocs.cloud/v1.0/parser/storage/file/move/parserdocs%2Fone-page1.docx?destPath#parserdocs1%2Fone-page1.docx'&#x26;srcStorageName#MyStorage&#x26;destStorageName#MyStorage" -H  "accept: application/json" -H  "authorization: Bearer [Access Token]"
-    
- ```
-
-
-
-
- Response
-
-```html 
+```json
 {
   "Code": 200,
   "Status": "OK"
 }
- ```
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-## SDKs ##
+### SDKs ###
 
 Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [File API](https://apireference.groupdocs.cloud/parser/#/File) calls and lets you use GroupDocs for Cloud features in a native way for your preferred language.
-|---|---|---|---|---|---
 
-### SDK Examples ###
+#### SDK Examples ####
 
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="10" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Move_File.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
-{{< gist groupdocscloud 4b05c33e76577ff3c4e35778db3f5ad5 Parser_Java_Move_File.java >}}
-
-
-
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
+{{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Move_File.java >}}
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/storage-operations/working-with-folder.md
+++ b/content/parser/developer-guide/storage-operations/working-with-folder.md
@@ -13,44 +13,36 @@ keywords: ""
 
 
 
-# Get the File Listing of a Specific Folder #
+## Get the File Listing of a Specific Folder ##
 
 This API allows you to get a list of all files of a specific folder from the specified Cloud Storage. If you do not pass storage name API will find the folder in GroupDocs Cloud Storage. 
 
-## API Explorer ##
+### API Explorer ###
 
 [GroupDocs.Parser Cloud API Reference](https://apireference.groupdocs.cloud/parser/) lets you try out [List Files in a Folder API](https://apireference.groupdocs.cloud/parser/#/Folder/GetFilesList) right away in your browser. It allows you to effortlessly interact and try out every single operation that our APIs expose.
-|---|---|---|---
 
-### Request parameters ###
+#### Request parameters ####
 
 |Parameter|Description
 |---|---
-|**path**|Path of the file including file name and extension e.g. /Folder1/file.ext
-
-Required. Can be passed as a query string parameter or as part of the URL
+|**path**|Path of the file including file name and extension e.g. /Folder1/file.ext</br>Required. Can be passed as a query string parameter or as part of the URL
 |storageName|Name of the storage. If not set, then default storage used
 
+### cURL Example ###
 
-## cURL Example ##
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
+```bash
+curl -X GET "https://api.groupdocs.cloud/v1.0/parser/storage/folder/parserdocs?storageName#MyStorage" \
+-H  "accept: application/json" \
+-H  "authorization: Bearer [Access Token]"
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
- Request
-
-```html 
-curl -X GET "https://api.groupdocs.cloud/v1.0/parser/storage/folder/parserdocs?storageName#MyStorage" -H  "accept: application/json" -H  "authorization: Bearer [Access Token]"
-
- ```
-
-
-
-
- Response
-
-```html 
+```json
 {
   "value": [
     {
@@ -111,398 +103,242 @@ curl -X GET "https://api.groupdocs.cloud/v1.0/parser/storage/folder/parserdocs?s
     }
   ]
 }
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
- ```
-
-
-
-
-
-
-## SDKs ##
+### SDKs ###
 
 Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [Folder API](https://apireference.groupdocs.cloud/parser/#/Folder) calls and lets you use GroupDocs Cloud features in a native way for your preferred language.
-|---|---|---|---|---|---
 
-### SDK Examples ###
+#### SDK Examples ####
 
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Get_Files_List.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Get_Files_List.java >}}
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-
-
-
-
-# Create a New Folder #
+## Create a New Folder ##
 
 This API allows you to create a new folder in the specified Cloud Storage. If you do not pass storage name API will create New Folder in default Cloud Storage.
 
-## API Explorer ##
+### API Explorer ###
 
 [GroupDocs.Parser Cloud API Reference](https://apireference.groupdocs.cloud/parser/) lets you try out [Create Folder API](https://apireference.groupdocs.cloud/parser/#/Folder/CreateFolder) right away in your browser. It allows you to effortlessly interact and try out every single operation that our APIs expose.
-|---|---|---|---
 
-
-### Request parameters ###
+#### Request parameters ####
 
 |Parameter|Description
 |---|---
-|**path**|Target folder’s path e.g. Folder1/Folder2/. The folders will be created recursively
-
-Required. Can be passed as a query string parameter or as part of the URL
+|**path**|Target folder’s path e.g. Folder1/Folder2/. The folders will be created recursively</br>Required. Can be passed as a query string parameter or as part of the URL
 |storageName|Name of the storage. If not set, then default storage used
 
+### cURL Example ###
 
-## cURL Example ##
+{{< tabs tabTotal="2" tabID="3" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
+```bash
+curl -X POST "https://api.groupdocs.cloud/v1.0/parser/storage/folder/parserdocs?storageName#MyStorage" \
+-H  "accept: application/json" \
+-H  "authorization: Bearer [Access Token]"
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
- Request
-
-```html 
-curl -X POST "https://api.groupdocs.cloud/v1.0/parser/storage/folder/parserdocs?storageName#MyStorage" -H  "accept: application/json" -H  "authorization: Bearer [Access Token]"
-
- ```
-
-
-
-
- Response
-
-```html 
+```json
 {  
   "code": 200,
   "status": "OK"
 }
- ```
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-## SDKs ##
+### SDKs ###
 
 Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [Folder API](https://apireference.groupdocs.cloud/parser/#/Folder/) calls and lets you use GroupDocs for Cloud features in a native way for your preferred language.
-|---|---|---|---|---|---
 
-### SDK Examples ###
+#### SDK Examples ####
 
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="4" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Create_Folder.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Create_Folder.java >}}
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-
-
-
-
-# Delete a Particular Folder #
+## Delete a Particular Folder ##
 
 This API allows you to delete a particular folder in the specified Cloud Storage. If you do not pass storage name API will create New Folder in default Cloud Storage. To remove recursively inner folder/files you need to pass true value to a recursive parameter in Request. If it is set to false and folder contains data then API throws the exception.
 
-## API Explorer ##
+### API Explorer ###
 
-[GroupDocs.Parser Cloud API Reference](https://apireference.groupdocs.cloud/parser/#/) lets you try out [Delete a Particular Folder API](https://apireference.groupdocs.cloud/parser/#/Folder/DeleteFolder) right away in your browser. It allows you to effortlessly interact and try out every single operation that our APIs expose. 
-|---|---|---|---
-
+[GroupDocs.Parser Cloud API Reference](https://apireference.groupdocs.cloud/parser/#/) lets you try out [Delete a Particular Folder API](https://apireference.groupdocs.cloud/parser/#/Folder/DeleteFolder) right away in your browser. It allows you to effortlessly interact and try out every single operation that our APIs expose.
 
 ### Request parameters ###
 
 |Parameter|Description
 |---|---
-|**path**|Folder path e.g. /Folder1
-
-Required. Can be passed as a query string parameter or as part of the URL
+|**path**|Folder path e.g. /Folder1</br>Required. Can be passed as a query string parameter or as part of the URL
 |storageName|Name of the storage. If not set, then default storage used
 
+### cURL Example ###
 
-## cURL Example ##
+{{< tabs tabTotal="2" tabID="5" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
+```bash
+curl -X DELETE "https://api.groupdocs.cloud/v1.0/parser/storage/folder/parserdocs?storageName#MyStorage&#x26;recursive#true" \
+-H  "accept: application/json" 
+-H  "authorization: Bearer [Access Token]"
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
- Request
-
-```html 
-curl -X DELETE "https://api.groupdocs.cloud/v1.0/parser/storage/folder/parserdocs?storageName#MyStorage&#x26;recursive#true" -H  "accept: application/json" -H  "authorization: Bearer [Access Token]"
-
- ```
-
-
-
-
- Response
-
-```html 
+```json
 {  
   "code": 200,
   "status": "OK"
 }
- ```
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-## SDKs ##
+### SDKs ###
 
 Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [Delete Folder API](https://apireference.groupdocs.cloud/parser/#/Folder/DeleteFolder) calls and lets you use GroupDocs for Cloud features in a native way for your preferred language.
-|---|---|---|---|---|---
 
-### SDK Examples ###
+#### SDK Examples ####
 
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="6" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Delete_Folder.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Delete_Folder.java >}}
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-
-
-
-
-# Copy  Specific Folder #
+## Copy  Specific Folder ##
 
 This API allows you to copy a Folder to another location in the GroupDocs Cloud Storage. If you do not pass source and destination storage names API will copy Folder within default Cloud Storage.
 
-## API Explorer ##
+### API Explorer ###
 
 [GroupDocs.Parser Cloud API Reference](https://apireference.groupdocs.cloud/parser/#/) lets you try out [Copy Folder API](https://apireference.groupdocs.cloud/parser/#/Folder/CopyFolder) right away in your browser. It allows you to effortlessly interact and try out every single operation that our APIs expose.
-|---|---|---|---
 
-### Request parameters ###
+#### Request parameters ####
 
 |Parameter|Description
 |---|---
-|**srcPath**|Source folder path e.g. /Folder1
-
-Required. Can be passed as a query string parameter or as part of the URL
+|**srcPath**|Source folder path e.g. /Folder1</br>Required. Can be passed as a query string parameter or as part of the URL
 |**destPath**|Destination folder path. Required
 |srcStorageName|Name of the storage of source folder. If not set, then default storage used
 |destStorageName|Name of the storage of destination folder. If not set, then default storage used
 
+### cURL Example ###
 
-## cURL Example ##
+{{< tabs tabTotal="2" tabID="7" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
+```bash
+curl -X PUT "https://api.groupdocs.cloud/v1.0/parser/storage/folder/copy/parserdocs?destPath#viewerdocs1&#x26;srcStorageName#MyStorage&#x26;destStorageName#MyStorage" \
+-H  "accept: application/json" \
+-H  "authorization: Bearer [Access Token]"
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
- Request
-
-```html 
-curl -X PUT "https://api.groupdocs.cloud/v1.0/parser/storage/folder/copy/parserdocs?destPath#viewerdocs1&#x26;srcStorageName#MyStorage&#x26;destStorageName#MyStorage" -H  "accept: application/json" -H  "authorization: Bearer [Access Token]"
-
- ```
-
-
-
-
- Response
-
-```html 
+```json
 {  
   "code": 200,
   "status": "OK"
 }
- ```
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-## SDKs ##
+### SDKs ###
 
 Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [Copy Folder API](https://apireference.groupdocs.cloud/parser/#/Folder/CopyFolder) calls and lets you use GroupDocs Cloud features in a native way for your preferred language.
-|---|---|---|---|---|---
 
-### SDK Examples ###
+#### SDK Examples ####
 
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="8" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Copy_Folder.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud 4b05c33e76577ff3c4e35778db3f5ad5 Viewer_Java_Copy_Folder.java >}}
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-
-
-
-
-# Move a Specific Folder #
+## Move a Specific Folder ##
 
 This API allows you to move a folder to another location in the GroupDocs Cloud Storage. If you do not pass source and destination storage names API will move Folder within default Cloud Storage.
 
-## API Explorer ##
+### API Explorer ###
 
 [GroupDocs.Parser Cloud API Reference](https://apireference.groupdocs.cloud/parser/#/) lets you try out [Move a Folder API](https://apireference.groupdocs.cloud/parser/#/Folder/MoveFolder) right away in your browser. It allows you to effortlessly interact and try out every single operation that our APIs expose.
-|---|---|---|---
 
-### Request parameters ###
+#### Request parameters ####
 
 |Parameter|Description
 |---|---
-|**srcPath**|Source folder path e.g. /Folder1
-
-Required. Can be passed as a query string parameter or as part of the URL
+|**srcPath**|Source folder path e.g. /Folder1</br>Required. Can be passed as a query string parameter or as part of the URL
 |**destPath**|Destination folder path. Required
 |srcStorageName|Name of the storage of source folder. If not set, then default storage used
 |destStorageName|Name of the storage of destination folder. If not set, then default storage used
 
+### cURL Example ###
 
-## cURL Example ##
+{{< tabs tabTotal="2" tabID="9" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
+```bash
+curl -X PUT "https://api.groupdocs.cloud/v1.0/parser/storage/folder/move/parserdocs?destPath#viewerdocs1&#x26;srcStorageName#MyStorage&#x26;destStorageName#MyStorage" \
+-H  "accept: application/json" \
+-H  "authorization: Bearer [Access Token]"  
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
- Request
-
-```html 
-curl -X PUT "https://api.groupdocs.cloud/v1.0/parser/storage/folder/move/parserdocs?destPath#viewerdocs1&#x26;srcStorageName#MyStorage&#x26;destStorageName#MyStorage" -H  "accept: application/json" -H  "authorization: Bearer [Access Token]"  
- ```
-
-
- Response
-
-```html 
+```json
 {  
   "code": 200,
   "status": "OK"
 }
- ```
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
-
-## SDKs ##
+### SDKs ###
 
 Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [Move Folder API](https://apireference.groupdocs.cloud/parser/#/Folder/MoveFolder) calls and lets you use GroupDocs Cloud features in a native way for your preferred language.
-|---|---|---|---|---|---
 
-### SDK Examples ###
+#### SDK Examples ####
 
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="10" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Move_Folder.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Move_Folder.java >}}
-
-
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/storage-operations/working-with-storage.md
+++ b/content/parser/developer-guide/storage-operations/working-with-storage.md
@@ -13,303 +13,196 @@ keywords: ""
 
 
 
-# Storage existence API #
+## Storage existence API ##
 
 This API intended for checking the existence of cloud storage with a given name from [GroupDocs Cloud Storage](https://dashboard.groupdocs.cloud).
-|---|---
 
-## API Explorer ##
+### API Explorer ###
 
 [GroupDocs.Parser Cloud API Reference](https://apireference.groupdocs.cloud/parser/#/) lets you try out [Storage existence API](https://apireference.groupdocs.cloud/parser/#/Storage/StorageExists) right away in your browser! It allows you to effortlessly interact and try out every single operation our APIs expose.
-|---|---|---|---
 
-### Request parameters ###
+#### Request parameters ####
 
 |Parameter|Description
 |---|---
 |**storageName**|Storage name
 
+### cURL Example ###
 
-## cURL Example ##
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
+```bash
+curl -X GET "https://api.groupdocs.cloud/v1.0/parser/storage/MyStorage/exist" \
+-H  "accept: application/json" \
+-H  "authorization: Bearer  [Access Token]"
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
- Request
-
-```html 
-curl -X GET "https://api.groupdocs.cloud/v1.0/parser/storage/MyStorage/exist" -H  "accept: application/json" -H  "authorization: Bearer  [Access Token]"
-    
- ```
-
-
-
-
- Response
-
-```html 
+```json
 {
   "exists": true
 }
- ```
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
+### SDKs ###
 
+Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [Storage existence](https://apireference.groupdocs.cloud/parser/#/Storage/StorageExists) calls and lets you use GroupDocs Cloud features in a native way for your preferred language.
 
+#### SDK Examples ####
 
-
-## SDKs ##
-
-Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser -cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [Storage existence](https://apireference.groupdocs.cloud/parser /#/Storage/StorageExists) calls and lets you use GroupDocs Cloud features in a native way for your preferred language.
-|---|---|---|---|---|---
-
-### SDK Examples ###
-
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Storage_Exist.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Storage_Exist.java >}}
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-
-
-
-
-# Storage object existence API #
+## Storage object existence API ##
 
 This API intended for checking the existence of a file or folder in [GroupDocs Cloud Storage](https://dashboard.groupdocs.cloud).
-|---|---
 
-## API Explorer ##
+### API Explorer ###
 
 [GroupDocs.Parser Cloud API Reference](https://apireference.groupdocs.cloud/parser/#/) lets you try out [Storage existence API](https://apireference.groupdocs.cloud/parser/#/Storage/StorageExists) right away in your browser! It allows you to effortlessly interact and try out every single operation our APIs expose.
-|---|---|---|---
 
-### Request parameters ###
+#### Request parameters ####
 
 |Parameter|Description
 |---|---
-|**path**|Path of the file or folder
-
-Required. Can be passed as a query string parameter or as part of the URL
+|**path**|Path of the file or folder</br>Required. Can be passed as a query string parameter or as part of the URL
 |storageName|Name of the storage. If not set, then default storage used
 |versionId|File version id
 
+### cURL Example ###
 
-## cURL Example ##
+{{< tabs tabTotal="2" tabID="3" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
+```bash
+curl -X GET "https://api.groupdocs.cloud/v1.0/parser/storage/exist/viewerdocs?storageName#MyStorage" \
+-H  "accept: application/json" \
+-H  "authorization: Bearer [Access Token]"
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
- Request
-
-```html 
-curl -X GET "https://api.groupdocs.cloud/v1.0/parser/storage/exist/viewerdocs?storageName#MyStorage" -H  "accept: application/json" -H  "authorization: Bearer [Access Token]"
- ```
-
-
-
-
- Response
-
-```html 
+```json
 {
   "exists": true,
   "isFolder": true
 }
- ```
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-## SDKs ##
+### SDKs ###
 
 Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [Storage Object existence](https://apireference.groupdocs.cloud/parser/#/Storage/ObjectExists) calls and lets you use GroupDocs Cloud features in a native way for your preferred language.
-|---|---|---|---|---|---
 
-### SDK Examples ###
+#### SDK Examples ####
 
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="4" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Object_Exists.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Object_Exists.java >}}
+{{< /tab >}}
+{{< /tabs >}}
 
+## Storage Space Usage API ##
 
+This API intended for getting total and used space of the [GroupDocs Cloud Storage](https://dashboard.groupdocs.cloud)
 
-
-
-
-
-
-
-# Storage Space Usage API #
-
-This API intended for getting total and used space of the[ GroupDocs Cloud Storage](https://dashboard.groupdocs.cloud)
-|---|---
-
-## API Explorer ##
+### API Explorer ###
 
 [GroupDocs.Parser Cloud API Reference](https://apireference.groupdocs.cloud/parser/#/) lets you try out [storage space usage API](https://apireference.groupdocs.cloud/parser/#/Storage/GetDiscUsage) right away in your browser! It allows you to effortlessly interact and try out every single operation our APIs expose.
-|---|---|---|---
+
+#### Request parameters ####
+
+|Parameter|Description
+|---|---
+|storageName|Name of the storage. If not set, then default storage used
+
+### cURL Example ###
+
+{{< tabs tabTotal="2" tabID="5" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
+
+```bash
+curl -X GET "https://api.groupdocs.cloud/v1.0/parser/storage/disc?storageName#MyStorage" \
+-H  "accept: application/json" \
+-H  "authorization: Bearer [Access Token]"
+```
+
+{{< /tab >}}
+{{< tab tabNum="2" >}}
+
+```json
+{
+  "usedSize": 31032368,
+  "totalSize": 3221225472
+}
+```
+
+{{< /tab >}}
+{{< /tabs >}}
+
+### SDKs ###
+
+Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [storage space usage API](https://apireference.groupdocs.cloud/parser/#/Storage/GetDiscUsage) calls and lets you use GroupDocs Cloud features in a native way for your preferred language.
+
+#### SDK Examples ####
+
+{{< tabs tabTotal="2" tabID="6" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
+{{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Get_Disc_Usage.cs >}}
+{{< /tab >}}
+{{< tab tabNum="2" >}}
+{{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Get_Disc_Usage.java >}}
+{{< /tab >}}
+{{< /tabs >}}
+
+## Storage File Versions API ##
+
+This API intended for getting the list of file versions, stored in the [GroupDocs Cloud Storage](https://dashboard.groupdocs.cloud)
+
+### API Explorer ###
+
+[GroupDocs.Parser Cloud API Reference](https://apireference.groupdocs.cloud/parser/#/) lets you try out [Storage File Versions API](https://apireference.groupdocs.cloud/parser/#/Storage/GetFileVersions) right away in your browser! It allows you to effortlessly interact and try out every single operation our APIs expose.
 
 ### Request parameters ###
 
 |Parameter|Description
 |---|---
+|**path**|Path of the file including file name and extension e.g. /Folder1/file.ext</br>Required. Can be passed as a query string parameter or as part of the URL
 |storageName|Name of the storage. If not set, then default storage used
 
+### cURL Example ###
 
-## cURL Example ##
+{{< tabs tabTotal="2" tabID="7" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
+```bash
+curl -X GET "https://api.groupdocs.cloud/v1.0/parser/storage/version/one-page.docx?storageName#MyStorage" \
+-H  "accept: application/json" \
+-H  "authorization: Bearer [Access Token]"
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
-
-
- Request
-
-```html 
-curl -X GET "https://api.groupdocs.cloud/v1.0/parser/storage/disc?storageName#MyStorage" -H  "accept: application/json" -H  "authorization: Bearer [Access Token]"
- ```
-
-
-
-
- Response
-
-```html 
-{
-  "usedSize": 31032368,
-  "totalSize": 3221225472
-}
- ```
-
-
-
-
-
-
-## SDKs ##
-
-Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [storage space usage API](https://apireference.groupdocs.cloud/parser/#/Storage/GetDiscUsage) calls and lets you use GroupDocs Cloud features in a native way for your preferred language.
-|---|---|---|---|---|---
-
-### SDK Examples ###
-
-
-
-
-
- C#
-
-
-
-
-{{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Get_Disc_Usage.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
-{{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Get_Disc_Usage.java >}}
-
-
-
-
-
-
-
-
-
-# Storage File Versions API #
-
-This API intended for getting the list of file versions, stored in the [GroupDocs Cloud Storage](https://dashboard.groupdocs.cloud)
-|---|---
-
-## API Explorer ##
-
-[GroupDocs.Parser Cloud API Reference](https://apireference.groupdocs.cloud/parser/#/) lets you try out [Storage File Versions API](https://apireference.groupdocs.cloud/parser/#/Storage/GetFileVersions) right away in your browser! It allows you to effortlessly interact and try out every single operation our APIs expose.
-|---|---|---|---
-
-##### Request parameters #####
-
-|Parameter|Description
-|---|---
-|**path**|Path of the file including file name and extension e.g. /Folder1/file.ext
-
-Required. Can be passed as a query string parameter or as part of the URL
-|storageName|Name of the storage. If not set, then default storage used
-
-
-## cURL Example ##
-
-
-
-
-
- Request
-
-```html 
-curl -X GET "https://api.groupdocs.cloud/v1.0/parser/storage/version/one-page.docx?storageName#MyStorage" -H  "accept: application/json" -H  "authorization: Bearer [Access Token]"
- ```
-
-
-
-
- Response
-
-```html 
+```json
 {
   "value": [
     {
@@ -323,47 +216,22 @@ curl -X GET "https://api.groupdocs.cloud/v1.0/parser/storage/version/one-page.do
     }
   ]
 }
- ```
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
-
-
-
-
-## SDKs ##
+### SDKs ###
 
 Our API is completely independent of your operating system, database system or development language. You can use any language and platform that supports HTTP to interact with our API. However, manually writing client code can be difficult, error-prone and time-consuming. Therefore, we have provided and support API [SDKs](https://github.com/groupdocs-parser-cloud) in many development languages in order to make it easier to integrate with us. If you use [SDK](https://github.com/groupdocs-parser-cloud), it hides the [Storage File Versions API](https://apireference.groupdocs.cloud/parser/#/Storage/GetFileVersions) calls and lets you use GroupDocs Cloud features in a native way for your preferred language.
-|---|---|---|---|---|---
 
-### SDK Examples ###
+#### SDK Examples ####
 
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="8" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Get_File_Versions.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Get_File_Versions.java >}}
-
-
-
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/template-operations/_index.md
+++ b/content/parser/developer-guide/template-operations/_index.md
@@ -9,6 +9,3 @@ keywords: ""
 ---
 
 ### Template Operations ###
-
-
-

--- a/content/parser/developer-guide/template-operations/create-or-update-template.md
+++ b/content/parser/developer-guide/template-operations/create-or-update-template.md
@@ -13,14 +13,9 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
-This REST API provides the functionality to save or update files that can be used in Parse endpoint. It's easy to define and save the template to extract data from invoices, prices or other kinds of your typical documents.
-
-The table below contains the full list of properties.
-
-
- 
+This REST API provides the functionality to save or update files that can be used in Parse endpoint. It's easy to define and save the template to extract data from invoices, prices or other kinds of your typical documents. The table below contains the full list of properties.
 
 |Name|Description|Comment
 |---|---|---
@@ -28,10 +23,7 @@ The table below contains the full list of properties.
 |FileInfo.StorageName|Storage name|It could be omitted for default storage.
 |Template|User-generated template to extract metadata from the document.|Required.
 
-
 ### Template ###
-
-{{id name#"TemplateParametersTable"/}}
 
 |Name|Description|Comment
 |---|---|---
@@ -48,84 +40,65 @@ The table below contains the full list of properties.
 |FieldPosition.IsTopLinked|The value that indicates whether a field is searched by the top from the linked field.|It is used if “Linked” FieldPositionType is set.
 |FieldPosition.IsBottomLinked|The value that indicates whether a field is searched by the bottom from the linked field.|It is used if “Linked” FieldPositionType is set.
 |FieldPosition.SearchArea|The size of the area where a field is searched.|Required if “Linked” FieldPositionType is set.
-|SearchArea.Height|The height of the search area.| 
-|SearchArea.Width|The width of the search area.| 
+|SearchArea.Height|The height of the search area.|
+|SearchArea.Width|The width of the search area.|
 |FieldPosition.AutoScale|The value that indicates whether SearchArea is scaled by the linked field size.|It is used if “Linked” FieldPositionType is set.
 |Template.Tables|Template tables.|Required if Template. Fields are not provided.
 |Table.FieldName|A unique template table name.|Required.
 |Table.PageIndex|The page index.|An integer value that represents the index of the page where the template item is located; null if the template item is located on any page.
 |Table.DetectorParametes|It provides parameters for the table detection algorithms.|Required if TableLayout is not provided.
-|DetectorParameters.MinRowCount|The minimum number of table rows.| 
-|DetectorParameters.MinColumnCount|The minimum number of table columns.| 
-|DetectorParameters.MinVerticalSpace|The minimum space between the table columns.| 
-|DetectorParameters.HasMergedCells|The value that indicates whether the table has merged cells.| 
-|DetectorParameters.Rectangle|The rectangular area that contains the table.| 
-|DetectorParameters.VerticalSeparators|The table columns separators.| 
+|DetectorParameters.MinRowCount|The minimum number of table rows.|
+|DetectorParameters.MinColumnCount|The minimum number of table columns.|
+|DetectorParameters.MinVerticalSpace|The minimum space between the table columns.|
+|DetectorParameters.HasMergedCells|The value that indicates whether the table has merged cells.|
+|DetectorParameters.Rectangle|The rectangular area that contains the table.|
+|DetectorParameters.VerticalSeparators|The table columns separators.|
 |Table.TableLayout|Provides the template table layout which is used Table to define table position.|Required if DetectorParameters is not provided.
-|TableLayout.VerticalSeparators|The table columns separators.| 
-|TableLayout.HorizontalSeparators|The table rows separators.| 
-
+|TableLayout.VerticalSeparators|The table columns separators.|
+|TableLayout.HorizontalSeparators|The table rows separators.|
 
 ### Rectangle ###
-
-{{id name#"RectangleParametersTable"/}}
 
 |Name|Description|Comment
 |---|---|---
 |Rectangle.Position|The coordinates of the upper-left corner of the rectangular area.|Required if Rectangle. Coordinates are not provided.
-|Position.X|X-coordinate of upper-left rectangle corner.| 
-|Position.Y|Y-coordinate of upper-left rectangle corner.| 
+|Position.X|X-coordinate of upper-left rectangle corner.|
+|Position.Y|Y-coordinate of upper-left rectangle corner.|
 |Rectangle.Size|Represents the size of rectangular area.|Required if Rectangle. Coordinates are not provided.
-|Size.Height|The height of the rectangular area.| 
-|Size.Width|The width of the rectangular area.| 
-|Rectangle.Coordinates|Coordinates of the rectangular area edges.| 
-|Coordinates.Top|The y-coordinate of the top edge of the rectangular area.| 
-|Coordinates.Right|The x-coordinate of the right edge of the rectangular area.| 
-|Coordinates.Left|The x-coordinate of the left edge of the rectangular area.| 
-|Coordinates.Bottom|The y-coordinate of the bottom edge of the rectangular area.| 
+|Size.Height|The height of the rectangular area.|
+|Size.Width|The width of the rectangular area.|
+|Rectangle.Coordinates|Coordinates of the rectangular area edges.|
+|Coordinates.Top|The y-coordinate of the top edge of the rectangular area.|
+|Coordinates.Right|The x-coordinate of the right edge of the rectangular area.|
+|Coordinates.Left|The x-coordinate of the left edge of the rectangular area.|
+|Coordinates.Bottom|The y-coordinate of the bottom edge of the rectangular area.|
 
+### Resource URI ##
 
-## Resource URI ##
-
-
-
- 
-
-```html 
-
+```html
 HTTP PUT ~/template
+```
 
- ```
+[Swagger UI](https://apireference.groupdocs.cloud/parser/#/Template/CreateTemplate) lets you call this REST API directly from the browser.
 
- 
-
-
-[Swagger UI](https://apireference.groupdocs.cloud/parser/#/Template/CreateTemplate) lets you call this REST API directly from the browser. 
-|---|---
-
-## cURL Example ##
+### cURL Example ###
 
 The following example demonstrates how to Create or Update Template.
 
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
-
- 
-
-
-
-
- Request
-
-```html 
-* First get JSON Web Token
-* Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications. Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
+```bash
+# First get JSON Web Token
+# Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications.
+# Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
 curl -v "https://api.groupdocs.cloud/connect/token" \
 -X POST \
 -d "grant_type#client_credentials&#x26;client_id#xxxx&#x26;client_secret#xxxx" \
 -H "Content-Type: application/x-www-form-urlencoded" \
 -H "Accept: application/json"
   
-* cURL example to join several documents into one
+# cURL example to join several documents into one
 curl -v "https://api.groupdocs.cloud/v1.0/parser/template" \
 -X PUT \
 -H "Content-Type: application/json" \
@@ -195,168 +168,34 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/template" \
     },
     "TemplatePath": "templates/template_2.json"
 }"
- ```
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
+Response will contain storage path and url to resultant template file
 
-
- Response
-
-```html 
-* Response will contain storage path and url to resultant template file
+```json
 {
     "url": "https://api.groupdocs.cloud/v1.0/parser/storage/file/templates/template_2.json",
     "templatePath": "templates/template_2.json"
+}
+```
 
- ```
+{{< /tab >}}
+{{< /tabs >}}
 
+## SDKs ##
 
+Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud) for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}}) article to learn how to add an SDK to your project.
 
+### Create or Update Template Examples ###
 
-
-
-
-
-
-
-
-
-
-
-
-```html 
-
-* First get JSON Web Token
-* Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications. Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
-curl -v "https://api.groupdocs.cloud/connect/token" \
--X POST \
--d "grant_type#client_credentials&#x26;client_id#xxxx&#x26;client_secret#xxxx" \
--H "Content-Type: application/x-www-form-urlencoded" \
--H "Accept: application/json"
-  
-* cURL example to join several documents into one
-curl -v "https://api.groupdocs.cloud/v1.0/parser/template" \
--X PUT \
--H "Content-Type: application/json" \
--H "Accept: application/json" \
--H "Authorization: Bearer 
-<jwt token>" \
--d "{
-    "Template": {
-        "Fields": [
-            {
-                "FieldName": "Address",
-                "FieldPosition": {
-                    "FieldPositionType": "Fixed",
-                    "Rectangle": {
-                        "Position": {
-                            "X": 13.0,
-                            "Y": 35.0
-                        },
-                        "Size": {
-                            "Height": 10.0,
-                            "Width": 100.0
-                        }
-                    },
-                    "MatchCase": false,
-                    "IsLeftLinked": false,
-                    "IsRightLinked": false,
-                    "IsTopLinked": false,
-                    "IsBottomLinked": false,
-                    "AutoScale": false
-                }
-            },
-            {
-                "FieldName": "Company",
-                "FieldPosition": {
-                    "FieldPositionType": "Linked",
-                    "MatchCase": false,
-                    "LinkedFieldName": "Address",
-                    "IsLeftLinked": false,
-                    "IsRightLinked": false,
-                    "IsTopLinked": false,
-                    "IsBottomLinked": true,
-                    "SearchArea": {
-                        "Height": 15.0,
-                        "Width": 100.0
-                    },
-                    "AutoScale": true
-                }
-            }
-        ],
-        "Tables": [
-            {
-                "TableName": "Totals",
-                "DetectorParameters": {
-                    "Rectangle": {
-                        "Position": {
-                            "X": 300.0,
-                            "Y": 385.0
-                        },
-                        "Size": {
-                            "Height": 220.0,
-                            "Width": 65.0
-                        }
-                    }
-                }
-            }
-        ]
-    },
-    "TemplatePath": "templates/template_2.json"
-}"
-
- ```
-
-
-
-
-
-
- Response
-
-```html 
-* Response will contain storage path and url to resultant template file
-{
-    "url": "https://api.groupdocs.cloud/v1.0/parser/storage/file/templates/template_2.json",
-    "templatePath": "templates/template_2.json"
-
- ```
-
-
-
-  
-
-
-
-# SDKs #
-
-Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud) for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}})) article to learn how to add an SDK to your project.
-|---|---|---|---
-
-## Create or Update Template Examples ##
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Create_Update_Template.cs >}}
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Create_Update_Template.java >}}
-
-
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/template-operations/delete-template.md
+++ b/content/parser/developer-guide/template-operations/delete-template.md
@@ -13,54 +13,43 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
-This REST API provides the functionality to remove files which no more useful in Parse endpoint. You can use [storage methods]({{< ref "parser/developer-guide/storage-operations/_index.md" >}})) to remove template files as well.
-|---|---
-
-The table below contains the full list of properties.
-
- 
+This REST API provides the functionality to remove files which no more useful in Parse endpoint. You can use [storage methods]({{< ref "parser/developer-guide/storage-operations/_index.md" >}}) to remove template files as well. The table below contains the full list of properties.
 
 |Name|Description|Comment
 |---|---|---
 |TemplatePath|The path of the template, located in the storage.|**Required.**
 |FileInfo.StorageName|Storage name|It could be omitted for default storage.
 
-
-## Resources ##
+### Resources ###
 
 The following GroupDocs.Parser Cloud REST API resource has been used in the [Delete Template](https://apireference.groupdocs.cloud/parser/#/Template/DeleteTemplate) example.
-|---|---
 
 **Resource URI**
 
-```html 
-
+```html
 HTTP DELETE ~/template
+```
 
- ```
-
-## cURL Example ##
+### cURL Example ###
 
 The following example demonstrates how to Delete a Template.
 
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
-
-
-
- Request
-
-```html 
- * First get JSON Web Token
-* Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications. Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
+```bash
+# First get JSON Web Token
+# Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications.
+# Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
 curl -v "https://api.groupdocs.cloud/connect/token" \
 -X POST \
 -d "grant_type#client_credentials&#x26;client_id#xxxx&#x26;client_secret#xxxx" \
 -H "Content-Type: application/x-www-form-urlencoded" \
 -H "Accept: application/json"
   
-* cURL example to join several documents into one
+# cURL example to join several documents into one
 curl -v "https://api.groupdocs.cloud/v1.0/parser/template" \
 -X PUT \
 -H "Content-Type: application/json" \
@@ -70,56 +59,29 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/template" \
 -d "{
     "TemplatePath": "templates/template_1.json"
 }"
- ```
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
+```html
+An empty response with '204 No Content' is returned to confirm deletion.
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
- Response
+### SDKs ###
 
-```html 
-* An empty response with '204 No Content' is returned to confirm deletion.
- ```
+Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud) for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}}) article to learn how to add an SDK to your project.
 
+#### Delete Template Examples ####
 
-
-
-
-
-## SDKs ##
-
-Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}})) article to learn how to add an SDK to your project.
-|---|---|---|---
-
-### Delete Template Examples ###
-
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Delete_Template.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Delete_Template.java >}}
-
-
-
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/developer-guide/template-operations/get-template.md
+++ b/content/parser/developer-guide/template-operations/get-template.md
@@ -13,46 +13,37 @@ keywords: ""
 
 
 
-# Introduction #
+## Introduction ##
 
-This REST API provides the functionality to retrieve templates that are used in Parse endpoint. Simply get the API response and use it as a template parameter in Parse by the Template method.
+This REST API provides the functionality to retrieve templates that are used in Parse endpoint. Simply get the API response and use it as a template parameter in Parse by the Template method. The table below contains the full list of properties.
 
-The table below contains the full list of properties.
-
-|Name
-|---
-|Description
-|Comment
-
+|Name|Description|Comment
+|---|---|---
 |TemplatePath|The path of the template, located in the storage.|**Required.**
 |FileInfo.StorageName|Storage name|It could be omitted for default storage.
 
-
-## Resource ##
+### Resource ###
 
 The following GroupDocs.Parser Cloud REST API resource has been used in the [Get Template](https://apireference.groupdocs.cloud/parser/#/Template/GetTemplate) example.
-|---|---
 
-## cURL Example ##
+### cURL Example ###
 
 The following example demonstrates how to Get a Template.
 
+{{< tabs tabTotal="2" tabID="1" tabName1="Request" tabName2="Response" >}}
+{{< tab tabNum="1" >}}
 
-
-
-
- Request
-
-```html 
-* First get JSON Web Token
-* Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications. Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
+```bash
+# First get JSON Web Token
+# Please get your Client Id and Client Secret from https://dashboard.groupdocs.cloud/applications.
+# Kindly place Client Id in "client_id" and Client Secret in "client_secret" argument.
 curl -v "https://api.groupdocs.cloud/connect/token" \
 -X POST \
 -d "grant_type#client_credentials&#x26;client_id#xxxx&#x26;client_secret#xxxx" \
 -H "Content-Type: application/x-www-form-urlencoded" \
 -H "Accept: application/json"
    
-* cURL example to join several documents into one
+# cURL example to join several documents into one
 curl -v "https://api.groupdocs.cloud/v1.0/parser/template" \
 -X POST \
 -H "Content-Type: application/json" \
@@ -62,18 +53,14 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/template" \
 -d "{
     "TemplatePath": "templates/template_1.json"
 }"
+```
 
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 
+Response will contain raw json template
 
- ```
-
-
-
-
- Response
-
-```html 
-* Response will contain raw json template
+```json
 {
     "fields": [
         {
@@ -134,50 +121,22 @@ curl -v "https://api.groupdocs.cloud/v1.0/parser/template" \
         }
     ]
 }
+```
 
+{{< /tab >}}
+{{< /tabs >}}
 
+### SDKs ###
 
- ```
+Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud) for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}}) article to learn how to add an SDK to your project.
 
+#### Get Template Examples ####
 
-
-
-
-
-## SDKs ##
-
-Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project. Check out our [GitHub repository](https://github.com/groupdocs-parser-cloud for a complete list of GroupDocs.Parser Cloud SDKs along with working examples, to get you started in no time. Please check [Available SDKs]({{< ref "parser/getting-started/available-sdks.md" >}})) article to learn how to add an SDK to your project.
-|---|---|---|---
-
-### Get Template Examples ###
-
-
-
-
-
- C#
-
-
-
-
+{{< tabs tabTotal="2" tabID="2" tabName1="C#" tabName2="Java" >}}
+{{< tab tabNum="1" >}}
 {{< gist groupdocscloud 39135fbf5cfb74deeeae6c47eafb2473 Parser_CSharp_Get_Template.cs >}}
-
-
-
-
-
-
-
- Java
-
-
-
-
+{{< /tab >}}
+{{< tab tabNum="2" >}}
 {{< gist groupdocscloud c8b8e01a52ef2bae6fa5d78aba152238 Parser_Java_Get_Template.java >}}
-
-
-
-
-
-
-
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/parser/getting-started/available-sdks.md
+++ b/content/parser/getting-started/available-sdks.md
@@ -13,42 +13,24 @@ keywords: ""
 
 
 
-# GroupDocs.Parser Cloud SDKs #
+## GroupDocs.Parser Cloud SDKs ##
 
 GroupDocs.Parser Cloud is a modern REST-oriented API, that allows easy integration into existing systems.
 
-## Why use an SDK? ##
+### Why use an SDK? ###
 
 Using an SDK (API client) is the quickest way for a developer to speed up the development. An SDK takes care of a lot of low-level details of making requests and handling responses and lets you focus on writing code specific to your particular project.
 
-## SDK benefits ##
+### SDK benefits ###
 
 Our supported SDKs are 100% tested and out of the box running. These SDKs are open source and have the MIT license. You can use them and even customize them for absolutely free of charge.
 
-# Supported SDKs #
+## Supported SDKs ##
 
+.Net **GroupDocs.Parser Cloud SDK for .NET 2.0** allows you to work with GroupDocs.Parser Cloud REST APIs in your .NET applications quickly and easily, with zero initial cost:
 
+* [https://github.com/groupdocs-parser-cloud/groupdocs-parser-cloud-dotnet](https://github.com/groupdocs-parser-cloud/groupdocs-parser-cloud-dotnet)
 
+Java **GroupDocs.Parser Cloud SDK for Java** allows you to work with GroupDocs.Parser Cloud REST APIs in your Java applications quickly and easily, with zero initial cost:
 
-
- .Net**GroupDocs.Parser Cloud SDK for .NET 2.0** allows you to work with GroupDocs.Parser Cloud REST APIs in your .NET applications quickly and easily, with zero initial cost:
-
-*  [https://github.com/groupdocs-parser-cloud/groupdocs-parser-cloud-dotnet](https://github.com/groupdocs-parser-cloud/groupdocs-parser-cloud-dotnet)
-
-
-
-
-
-
- Java**GroupDocs.Parser Cloud SDK for Java** allows you to work with GroupDocs.Parser Cloud REST APIs in your Java applications quickly and easily, with zero initial cost:
-
-*  [https://github.com/groupdocs-parser-cloud/groupdocs-parser-cloud-java](https://github.com/groupdocs-parser-cloud/groupdocs-parser-cloud-java)
-
-
-
-
-
-
-\\
-
-\\
+* [https://github.com/groupdocs-parser-cloud/groupdocs-parser-cloud-java](https://github.com/groupdocs-parser-cloud/groupdocs-parser-cloud-java)

--- a/content/parser/getting-started/how-to-run-the-examples.md
+++ b/content/parser/getting-started/how-to-run-the-examples.md
@@ -17,6 +17,3 @@ All examples of GroupDocs.Parser Cloud is hosted on [Github](https://github.com/
 If you like to add or improve an example, we encourage you to contribute to the project. All examples and showcase projects in this repository are open source and can be freely used in your own applications.
 
 To contribute, you can fork the repository, edit the source code and create a pull request. We will review the changes and include them in the repository if found helpful.
-
-
-\\

--- a/content/parser/getting-started/supported-document-formats.md
+++ b/content/parser/getting-started/supported-document-formats.md
@@ -8,277 +8,66 @@ description: ""
 keywords: ""
 ---
 
-
-
-
-
-
-
-# Supported Document Formats #
-
 The following table indicates the file formats from which GroupDocs.Parser Cloud can extract data.
 
-
-
- 
-
-|
-|---
-Document Type|
-Parse Document by Template|
-Extract Text|
-Extract Document Info|
-Extract Images|
-Extract Container Items Info
-|Word Processing
-|[DOC](https://wiki.fileformat.com/word-processing/doc/)|Microsoft Word Document|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[DOT](https://wiki.fileformat.com/word-processing/dot/)|Microsoft Word Document Template|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[DOCX](https://wiki.fileformat.com/word-processing/docx/)|Office Open XML Document|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[DOCM](https://wiki.fileformat.com/word-processing/docm/)|Office Open XML Macro-Enabled Document|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[DOTX](https://wiki.fileformat.com/word-processing/dotx/)|Office Open XML Document Template|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[DOTM](https://wiki.fileformat.com/word-processing/dotm/)|Office Open XML Document Macro-Enabled Template|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[TXT](https://wiki.fileformat.com/word-processing/txt/)|Plain text|
- |
-&#10004;|
- &#10004;|
- | 
-|[ODT](https://wiki.fileformat.com/word-processing/odt/)|Open Document Text|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[OTT](https://wiki.fileformat.com/word-processing/ott/)|Open Document Text Template|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[RTF](https://wiki.fileformat.com/word-processing/rtf/)|Rich Text Format|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|PDF 
-|[PDF](https://wiki.fileformat.com/view/pdf/)|Portable Document Format File|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;
-|Markup 
-|[HTML](https://wiki.fileformat.com/web/html/)|Hypertext Markup Language File| |
-&#10004;|
- &#10004;|
- | 
-|[XHTML](https://wiki.fileformat.com/web/xhtml/)|Extensible Hypertext Markup Language File| |
-&#10004;|
- &#10004;|
- | 
-|[MHTML](https://wiki.fileformat.com/web/mhtml/)|MIME HTML File| |
-&#10004;|
-&#10004; |
- | 
-|[MD](https://wiki.fileformat.com/word-processing/md/)|Markdown| |
-&#10004;|
- &#10004;|
- | 
-|[XML](https://wiki.fileformat.com/web/xml/)|XML File| |
-&#10004;|
- &#10004;|
- | 
-|Ebooks 
-|[CHM](https://wiki.fileformat.com/web/chm/)|Compiled HTML Help File| |
-&#10004;|
-&#10004; |
- | 
-|[EPUB](https://wiki.fileformat.com/ebook/epub/)|Digital E-Book File Format| |
-&#10004;|
-&#10004;|
- | 
-|[FB2](https://wiki.fileformat.com/ebook/fb2/)|FictionBook 2.0 File| |
-&#10004;|
-&#10004;|
- | 
-|Speadsheet 
-|[XLS](https://wiki.fileformat.com/specification/spreadsheet/xls/)|Microsoft Excel Spreadsheet|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[XLT](https://wiki.fileformat.com/specification/spreadsheet/xlt/)|Microsoft Excel Template|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[XLSX](https://wiki.fileformat.com/specification/spreadsheet/xlsx/)|Office Open XML Spreadsheet|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[XLSM](https://wiki.fileformat.com/specification/spreadsheet/xlsm/)|Office Open XML Macro-Enabled Spreadsheet|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[XLSB](https://wiki.fileformat.com/specification/spreadsheet/xlsb/)|Office Open XML Binary Spreadsheet|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[XLTX](https://wiki.fileformat.com/specification/spreadsheet/xltx/)|Office Open XML Spreadsheet Template|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[XLTM](https://wiki.fileformat.com/specification/spreadsheet/xltm/)|Office Open XML Macro-Enabled Spreadsheet Template|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[ODS](https://wiki.fileformat.com/specification/spreadsheet/ods/)|Open Document Spreadsheet|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|OTS|Open Document Spreadsheet Template|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[CSV](https://wiki.fileformat.com/specification/spreadsheet/csv/)|Comma Separated Values| |
-&#10004;|
- &#10004;|
- | 
-|XLA|Excel Add-In File|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|XLAM|Excel Open XML Macro-Enabled Add-In|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|NUMBERS|Apple iWork Numbers|
-&#10004;|
-&#10004;|
- &#10004;|
-&#10004;| 
+|Document Type|Parse Document by Template|Extract Text|Extract Document Info|Extract Images|Extract Container Items Info
+|---|---|---|---|---|---
+|Word Processing|
+|[DOC](https://wiki.fileformat.com/word-processing/doc/)|Microsoft Word Document|&#10004;|&#10004;|&#10004;|&#10004;|
+|[DOT](https://wiki.fileformat.com/word-processing/dot/)|Microsoft Word Document Template|&#10004;|&#10004;|&#10004;|&#10004;|
+|[DOCX](https://wiki.fileformat.com/word-processing/docx/)|Office Open XML Document|&#10004;|&#10004;|&#10004;|&#10004;|
+|[DOCM](https://wiki.fileformat.com/word-processing/docm/)|Office Open XML Macro-Enabled Document|&#10004;|&#10004;|&#10004;|&#10004;|
+|[DOTX](https://wiki.fileformat.com/word-processing/dotx/)|Office Open XML Document Template|&#10004;|&#10004;|&#10004;|&#10004;|
+|[DOTM](https://wiki.fileformat.com/word-processing/dotm/)|Office Open XML Document Macro-Enabled Template|&#10004;|&#10004;|&#10004;|&#10004;|
+|[TXT](https://wiki.fileformat.com/word-processing/txt/)|Plain text||&#10004;|&#10004;||
+|[ODT](https://wiki.fileformat.com/word-processing/odt/)|Open Document Text|&#10004;|&#10004;|&#10004;|&#10004;|
+|[OTT](https://wiki.fileformat.com/word-processing/ott/)|Open Document Text Template|&#10004;|&#10004;|&#10004;|&#10004;|
+|[RTF](https://wiki.fileformat.com/word-processing/rtf/)|Rich Text Format|&#10004;|&#10004;|&#10004;|&#10004;|
+|PDF
+|[PDF](https://wiki.fileformat.com/view/pdf/)|Portable Document Format File|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;
+|Markup
+|[HTML](https://wiki.fileformat.com/web/html/)|Hypertext Markup Language File||&#10004;|&#10004;||
+|[XHTML](https://wiki.fileformat.com/web/xhtml/)|Extensible Hypertext Markup Language File||&#10004;|&#10004;||
+|[MHTML](https://wiki.fileformat.com/web/mhtml/)|MIME HTML File||&#10004;|&#10004;||
+|[MD](https://wiki.fileformat.com/word-processing/md/)|Markdown||&#10004;|&#10004;||
+|[XML](https://wiki.fileformat.com/web/xml/)|XML File||&#10004;|&#10004;||
+|Ebooks
+|[CHM](https://wiki.fileformat.com/web/chm/)|Compiled HTML Help File||&#10004;|&#10004;||
+|[EPUB](https://wiki.fileformat.com/ebook/epub/)|Digital E-Book File Format||&#10004;|&#10004;||
+|[FB2](https://wiki.fileformat.com/ebook/fb2/)|FictionBook 2.0 File||&#10004;|&#10004;||
+|Speadsheet
+|[XLS](https://wiki.fileformat.com/specification/spreadsheet/xls/)|Microsoft Excel Spreadsheet|&#10004;|&#10004;|&#10004;|&#10004;|
+|[XLT](https://wiki.fileformat.com/specification/spreadsheet/xlt/)|Microsoft Excel Template|&#10004;|&#10004;|&#10004;|&#10004;|
+|[XLSX](https://wiki.fileformat.com/specification/spreadsheet/xlsx/)|Office Open XML Spreadsheet|&#10004;|&#10004;|&#10004;|&#10004;|
+|[XLSM](https://wiki.fileformat.com/specification/spreadsheet/xlsm/)|Office Open XML Macro-Enabled Spreadsheet|&#10004;|&#10004;|&#10004;|&#10004;|
+|[XLSB](https://wiki.fileformat.com/specification/spreadsheet/xlsb/)|Office Open XML Binary Spreadsheet|&#10004;|&#10004;|&#10004;|&#10004;|
+|[XLTX](https://wiki.fileformat.com/specification/spreadsheet/xltx/)|Office Open XML Spreadsheet Template|&#10004;|&#10004;|&#10004;|&#10004;|
+|[XLTM](https://wiki.fileformat.com/specification/spreadsheet/xltm/)|Office Open XML Macro-Enabled Spreadsheet Template|&#10004;|&#10004;|&#10004;|&#10004;|
+|[ODS](https://wiki.fileformat.com/specification/spreadsheet/ods/)|Open Document Spreadsheet|&#10004;|&#10004;|&#10004;|&#10004;|
+|OTS|Open Document Spreadsheet Template|&#10004;|&#10004;|&#10004;|&#10004;|
+|[CSV](https://wiki.fileformat.com/specification/spreadsheet/csv/)|Comma Separated Values| |&#10004;|&#10004;||
+|XLA|Excel Add-In File|&#10004;|&#10004;|&#10004;|&#10004;|
+|XLAM|Excel Open XML Macro-Enabled Add-In|&#10004;|&#10004;|&#10004;|&#10004;|
+|NUMBERS|Apple iWork Numbers|&#10004;|&#10004;|&#10004;|&#10004;|
 |Presentations
-|[PPT](https://wiki.fileformat.com/presentation/ppt/)|PowerPoint Presentation|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[PPS](https://wiki.fileformat.com/presentation/pps/)|PowerPoint Slideshow|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[POT](https://wiki.fileformat.com/presentation/pot/)|PowerPoint Template|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[PPTX](https://wiki.fileformat.com/presentation/pptx/)|Office Open XML Presentation|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[PPTM](https://wiki.fileformat.com/presentation/pptm/)|Office Open XML Macro-Enabled Presentation|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[POTX](https://wiki.fileformat.com/presentation/potx/)|Office Open XML Presentation Template|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[POTM](https://wiki.fileformat.com/presentation/potm/)|Office Open XML Macro-Enabled Presentation Template|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[PPSX](https://wiki.fileformat.com/presentation/ppsx/)|Office Open XML Presentation Slideshow|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[PPSM](https://wiki.fileformat.com/presentation/ppsm/)|Office Open XML Macro-Enabled Presentation Slideshow|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[ODP](https://wiki.fileformat.com/presentation/odp/)|Open Document Presentation|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|[OTP](https://wiki.fileformat.com/presentation/otp/)|Open Document Presentation Template|
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;| 
-|Emails 
-|[PST](https://wiki.fileformat.com/email/pst/)|Outlook Personal Information Store File| |
- |
- &#10004;|
- |
-&#10004;
-|[OST](https://wiki.fileformat.com/email/ost/)|Outlook Offline Data File| |
- |
- &#10004;|
- |
-&#10004;
-|[EML](https://wiki.fileformat.com/email/eml/)|E-Mail Message| |
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;
-|[EMLX](https://wiki.fileformat.com/email/emlx/)|Apple Mail Message| |
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;
-|[MSG](https://wiki.fileformat.com/email/msg/)|Outlook Mail Message| |
-&#10004;|
-&#10004;|
-&#10004;|
-&#10004;
-|Notes 
-|[ONE](https://wiki.fileformat.com/note-taking/one/)|OneNote Document| |
-&#10004;|
- &#10004;|
- | 
-|Archives 
-|[ZIP](https://wiki.fileformat.com/compression/zip/)|Zipped File| |
- |
- &#10004;|
-&#10004;|
-&#10004;
-
-
+|[PPT](https://wiki.fileformat.com/presentation/ppt/)|PowerPoint Presentation|&#10004;|&#10004;|&#10004;|&#10004;|
+|[PPS](https://wiki.fileformat.com/presentation/pps/)|PowerPoint Slideshow|&#10004;|&#10004;|&#10004;|&#10004;|
+|[POT](https://wiki.fileformat.com/presentation/pot/)|PowerPoint Template|&#10004;|&#10004;|&#10004;|&#10004;|
+|[PPTX](https://wiki.fileformat.com/presentation/pptx/)|Office Open XML Presentation|&#10004;|&#10004;|&#10004;|&#10004;|
+|[PPTM](https://wiki.fileformat.com/presentation/pptm/)|Office Open XML Macro-Enabled Presentation|&#10004;|&#10004;|&#10004;|&#10004;|
+|[POTX](https://wiki.fileformat.com/presentation/potx/)|Office Open XML Presentation Template|&#10004;|&#10004;|&#10004;|&#10004;|
+|[POTM](https://wiki.fileformat.com/presentation/potm/)|Office Open XML Macro-Enabled Presentation Template|&#10004;|&#10004;|&#10004;|&#10004;|
+|[PPSX](https://wiki.fileformat.com/presentation/ppsx/)|Office Open XML Presentation Slideshow|&#10004;|&#10004;|&#10004;|&#10004;|
+|[PPSM](https://wiki.fileformat.com/presentation/ppsm/)|Office Open XML Macro-Enabled Presentation Slideshow|&#10004;|&#10004;|&#10004;|&#10004;|
+|[ODP](https://wiki.fileformat.com/presentation/odp/)|Open Document Presentation|&#10004;|&#10004;|&#10004;|&#10004;|
+|[OTP](https://wiki.fileformat.com/presentation/otp/)|Open Document Presentation Template|&#10004;|&#10004;|&#10004;|&#10004;|
+|Emails
+|[PST](https://wiki.fileformat.com/email/pst/)|Outlook Personal Information Store File| ||&#10004;||&#10004;
+|[OST](https://wiki.fileformat.com/email/ost/)|Outlook Offline Data File| ||&#10004;||&#10004;
+|[EML](https://wiki.fileformat.com/email/eml/)|E-Mail Message| |&#10004;|&#10004;|&#10004;|&#10004;
+|[EMLX](https://wiki.fileformat.com/email/emlx/)|Apple Mail Message| |&#10004;|&#10004;|&#10004;|&#10004;
+|[MSG](https://wiki.fileformat.com/email/msg/)|Outlook Mail Message| |&#10004;|&#10004;|&#10004;|&#10004;
+|Notes
+|[ONE](https://wiki.fileformat.com/note-taking/one/)|OneNote Document| |&#10004;|&#10004;||
+|Archives
+|[ZIP](https://wiki.fileformat.com/compression/zip/)|Zipped File| ||&#10004;|&#10004;|&#10004;

--- a/content/parser/getting-started/supported-platforms.md
+++ b/content/parser/getting-started/supported-platforms.md
@@ -8,9 +8,4 @@ description: ""
 keywords: ""
 ---
 
-## Supported Platforms ##
-
 GroupDocs.Parser Cloud is a REST API that can be used with any language: .NET, Java, PHP, Ruby, Python, Node.js and many more. You can use it with any language or platform that supports REST. (Almost all platforms and languages support REST and provide native REST clients to work with REST APIs). You do not need to worry about language or platform limitations. You can use it with any platform – web, desktop, mobile, and cloud. The API integrates with other cloud services to give you the flexibility you need when processing documents. It is suitable for any type of business, document, or content.
-
-
-\\

--- a/content/parser/release-notes/2019/groupdocs-parser-for-cloud-19-11-release-notes.md
+++ b/content/parser/release-notes/2019/groupdocs-parser-for-cloud-19-11-release-notes.md
@@ -12,59 +12,47 @@ keywords: ""
 This page contains release notes for GroupDocs.Parser Cloud 19.11
 {{< /alert >}}
 
-# Overview #
+## Overview ##
 
-GroupDocs.Parser Cloud is a document data extraction REST API from over 50 document types. One of the most valuable features of GroupDocs.Parser Cloud is parsing documents with predefined templates. It's easy to define template and extract data from invoices, prices or other kinds of your typical documents. The API also provides methods to extract images, extract text. You can do it with regular documents and containers like ZIP archives, OST/PST mail data files and PDF portfolios.\\
+GroupDocs.Parser Cloud is a document data extraction REST API from over 50 document types. One of the most valuable features of GroupDocs.Parser Cloud is parsing documents with predefined templates. It's easy to define template and extract data from invoices, prices or other kinds of your typical documents. The API also provides methods to extract images, extract text. You can do it with regular documents and containers like ZIP archives, OST/PST mail data files and PDF portfolios.
 
-## Major Features ##
+### Major Features ###
 
 Below are the shortlist of possible actions / features availavle in GroupDocs.Parser Cloud API:
 
-### Parse Document by Template ###
+#### Parse Document by Template ####
 
-GroupDocs.Parser Cloud allows parsing documents by user-defined templates. It is easy to create a template with data field definitions, table definitions. Then it's easy to use the template and extract data such as text fields, numbers, tables from your typical documents. The template can be passed as an object. Also, you can save your named templates in the storage and parse your documents with them.\\
+GroupDocs.Parser Cloud allows parsing documents by user-defined templates. It is easy to create a template with data field definitions, table definitions. Then it's easy to use the template and extract data such as text fields, numbers, tables from your typical documents. The template can be passed as an object. Also, you can save your named templates in the storage and parse your documents with them.
 
-### Extract Text ###
+#### Extract Text ####
 
 GroupDocs.Parser Cloud provides text extraction method that covers various text retrieval scenarios:
 
-* 
-Extract a plain text from any of the supporting documents;
+* Extract a plain text from any of the supporting documents;
+* Extract HTML or Markdown-formatted text for a fast preview;
+* Extract particular pages of plain or formatted text.
 
-* 
-Extract HTML or Markdown-formatted text for a fast preview;
-
-* 
-Extract particular pages of plain or formatted text.
-
-
-### Extract Formatted Text ###
+#### Extract Formatted Text ####
 
 In addition to standard text extraction modes, GroupDocs.Parser Cloud API provides an option to extract a formatted text for those cases when simple plain text is not enough and you may need to keep formatting like text style, table layout, etc. At this moment the following formats are supported:
 
-* 
-Plain Text
+* Plain Text
+* Markdown
+* HTML
 
-* 
-Markdown
-
-* 
-HTML
-
-
-### Extract Images ###
+#### Extract Images ####
 
 GroupDocs.Parser Cloud supports Images extraction from documents. You may call this method and retrieve all document images and save them.
 
-### Document information extraction ###
+#### Document information extraction ####
 
 GroupDocs.Parser Cloud allows obtaining basic information about source document - file type, size, pages count. The API also provides a method to extract information about container items such as Zip archives, emails with attachments, Ost files or Pdf Portfolio.
 
-### Template Management ###
+#### Template Management ####
 
 GroupDocs.Parser Cloud provides methods that help you to create, update, retrieve and delete user-generated template files that are used in Parse by Document Template functionality.
 
-## API Endpoint Groups Overview ##
+### API Endpoint Groups Overview ###
 
 |Endpoint Group|Description
 |---|---
@@ -75,8 +63,6 @@ GroupDocs.Parser Cloud provides methods that help you to create, update, retriev
 |Folder|Contains endpoints for creating, copy, move, delete folders in the storage
 |Storage|Contains endpoints for obtaining storage information and file information
 
+### Public API Examples ###
 
-## Public API Examples ##
-
-* [GroupDocs Parser Cloud API examples and documentation]({{< ref "parser/_index.md" >}}))
-|---|---
+* [GroupDocs Parser Cloud API examples and documentation]({{< ref "parser/_index.md" >}})

--- a/content/parser/release-notes/release-notes-2020/groupdocs-parser-for-cloud-20-6-release-notes.md
+++ b/content/parser/release-notes/release-notes-2020/groupdocs-parser-for-cloud-20-6-release-notes.md
@@ -8,33 +8,31 @@ keywords: ""
 ---
 
 
-
+{{< alert style="info" >}}
 This page contains release notes for GroupDocs.Parser Cloud 20.6
-
+{{< /alert >}}
 
 ## Major Features ##
 
 * Added new SDK platforms:
-** Node.js
-** PHP
-** Python
-** Ruby
+  * Node.js
+  * PHP
+  * Python
+  * Ruby
 * Added new properties to the information about extracted image;
 * Added encoding field to document information extraction.
 
 ## Full List of Issues Covering all Changes in this Release ##
 
-
-|#Key|#Category|#Summary
-|PARSERCLOUD-111|Add Node.js SDK for GroupDocs.Parser Cloud|Feature
-|PARSERCLOUD-112|Add PHP SDK for GroupDocs.Parser Cloud|Feature
-|PARSERCLOUD-113|Add Python SDK for GroupDocs.Parser Cloud|Feature
-|PARSERCLOUD-114|Add Ruby SDK for GroupDocs.Parser Cloud|Feature
-|PARSERCLOUD-174|Implement extraction of encoding|Feature
-|PARSERCLOUD-175|Implement additional image information extraction|Feature
+|Key|Category|Summary
+|---|---|---
+|PARSERCLOUD-111|Feature|Add Node.js SDK for GroupDocs.Parser Cloud
+|PARSERCLOUD-112|Feature|Add PHP SDK for GroupDocs.Parser Cloud
+|PARSERCLOUD-113|Feature|Add Python SDK for GroupDocs.Parser Cloud
+|PARSERCLOUD-114|Feature|Add Ruby SDK for GroupDocs.Parser Cloud
+|PARSERCLOUD-174|Feature|Implement extraction of encoding
+|PARSERCLOUD-175|Feature|Implement additional image information extraction
 
 ### API examples and documentation ###
 
-* [GroupDocs Parser Cloud API Examples and documentation]({{< ref "parser/_index.md" >}}))
-
- 
+* [GroupDocs Parser Cloud API Examples and documentation]({{< ref "parser/_index.md" >}})


### PR DESCRIPTION
Issues outline:
* Tables off/broken: 1 page
* Small formatting issues: 6 pages
* Change from simple Request/Response block and code examples into tabs style (example: https://docs.groupdocs.cloud/annotation/working-with-storage-api/#sdk-examples-): 16 pages
* All kinds of issues: 3 pages